### PR TITLE
explicit sockJS option

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "centrifuge",
   "version": "1.3.6",
   "description": "Centrifuge javascript client",
-  "main": "centrifuge.js",
+  "main": "src/centrifuge.js",
   "dependencies": {
     "wolfy87-eventemitter": "4.3.0",
     "es6-promise": "3.0.2"


### PR DESCRIPTION
In order to solve #10 - provide SockJS object explicitly. So something like this can be used in ES6:
```javascript
import Centrifuge from 'centrifuge'
import SockJS from 'sockjs-client'

var c = new Centrifuge({
    "url": "...",
    "user": "...",
    "token": "...",
    "timestamp": "...",
    "sockJS": SockJS
});

c.connect();
```
Also use `src/centrifuge.js` as entry point in `package.json`