### PR TITLE
Prefer raw websocket option

### DIFF
--- a/src/centrifuge.js
+++ b/src/centrifuge.js
@@ -121,7 +121,8 @@ function errorExists(data) {
 }
 
 function Centrifuge(options) {
-    this._useSockJS = false;
+    this._sockJS = null;
+    this._isSockJS = false;
     this._status = 'disconnected';
     this._reconnect = true;
     this._reconnecting = false;
@@ -144,6 +145,8 @@ function Centrifuge(options) {
     this._callbacks = {};
     this._latency = null;
     this._latencyStart = null;
+    this._rawWebsocketFailed = false;
+    this._rawWebsocketTimeout = null;
     this._config = {
         sockJS: null,
         retry: 1000,
@@ -180,7 +183,8 @@ function Centrifuge(options) {
         authEndpoint: "/centrifuge/auth/",
         authHeaders: {},
         authParams: {},
-        authTransport: "ajax"
+        authTransport: "ajax",
+        preferRawWebsocket: true
     };
     if (options) {
         this.configure(options);
@@ -292,6 +296,32 @@ centrifugeProto._debug = function () {
     }
 };
 
+centrifugeProto._websocketSupported = function() {
+    return !(typeof WebSocket !== 'function' && typeof WebSocket !== 'object')
+};
+
+centrifugeProto._sockjsEndpoint = function() {
+    var url = this._config.url;
+    url = url.replace("ws://", "http://");
+    url = url.replace("wss://", "https://");
+    url = stripSlash(url);
+    if (!endsWith(this._config.url, 'connection')) {
+        url = url + "/connection";
+    }
+    return url;
+};
+
+centrifugeProto._rawWebsocketEndpoint = function() {
+    var url = this._config.url;
+    url = url.replace("http://", "ws://");
+    url = url.replace("https://", "wss://");
+    url = stripSlash(url);
+    if (!endsWith(this._config.url, 'connection/websocket')) {
+        url = url + "/connection/websocket";
+    }
+    return url;
+};
+
 centrifugeProto._configure = function (configuration) {
     this._debug('Configuring centrifuge object with', configuration);
 
@@ -336,35 +366,28 @@ centrifugeProto._configure = function (configuration) {
         this._debug("client will connect to SockJS endpoint");
         if (this._config.sockJS !== null) {
             this._debug("SockJS explicitly provided in options");
-            this._useSockJS = true;
-        } else if (typeof SockJS === 'undefined') {
-            throw 'include SockJS client library before Centrifuge javascript client library or use raw Websocket connection endpoint';
+            this._sockJS = this._config.sockJS;
         } else {
+            if (typeof SockJS === 'undefined') {
+                throw 'include SockJS client library before Centrifuge javascript client library or use raw Websocket connection endpoint';
+            }
             this._debug("use globally defined SockJS");
-            this._config.sockJS = SockJS;
-            this._useSockJS = true;
+            this._sockJS = SockJS;
         }
     } else if (endsWith(this._config.url, 'connection/websocket')) {
         this._debug("client will connect to raw Websocket endpoint");
-        this._config.url = this._config.url.replace("http://", "ws://");
-        this._config.url = this._config.url.replace("https://", "wss://");
     } else {
         this._debug("client will detect connection endpoint itself");
-        if (this._config.sockJS === null && typeof SockJS === 'undefined') {
-            this._debug("no SockJS found, client will connect to raw Websocket endpoint");
-            this._config.url += "/connection/websocket";
-            this._config.url = this._config.url.replace("http://", "ws://");
-            this._config.url = this._config.url.replace("https://", "wss://");
+        if (this._config.sockJS !== null) {
+            this._debug("SockJS explicitly provided in options");
+            this._sockJS = this._config.sockJS;
         } else {
-            this._debug("SockJS found, client will connect to SockJS endpoint");
-            if (this._config.sockJS !== null) {
-                this._debug("SockJS explicitly provided in options");
+            if (typeof SockJS === 'undefined') {
+                this._debug("SockJS not found");
             } else {
                 this._debug("use globally defined SockJS");
-                this._config.sockJS = SockJS;
+                this._sockJS = SockJS;
             }
-            this._config.url += "/connection";
-            this._useSockJS = true;
         }
     }
 };
@@ -450,26 +473,55 @@ centrifugeProto._send = function (messages) {
 };
 
 centrifugeProto._setupTransport = function() {
-    // detect transport to use - SockJS or raw Websocket
-    if (this._useSockJS === true) {
-        var sockjsOptions = {
-            "transports": this._config.transports
-        };
-        if (this._config.server !== null) {
-            sockjsOptions['server'] = this._config.server;
-        }
-        this._transport = new this._config.sockJS(this._config.url, null, sockjsOptions);
-    } else {
-        this._transport = new WebSocket(this._config.url);
+    var sockjsOptions = {
+        "transports": this._config.transports
+    };
+    if (this._config.server !== null) {
+        sockjsOptions['server'] = this._config.server;
     }
+    this._isSockJS = false;
 
     var self = this;
 
+    // detect transport to use - SockJS or raw Websocket
+    if (this._config.preferRawWebsocket) {
+        if (!this._websocketSupported()) {
+            if (!this._sockJS) {
+                this._debug("No Websocket support and no SockJS, can't connect");
+                return;
+            } else {
+                this._isSockJS = true;
+                this._transport = new this._sockJS(this._sockjsEndpoint(), null, sockjsOptions);
+            }
+        } else {
+            if (!this._rawWebsocketFailed || this._sockJS === null) {
+                this._transport = new WebSocket(this._rawWebsocketEndpoint());
+                this._rawWebsocketTimeout = setTimeout(function() {
+                    self._rawWebsocketFailed = true;
+                }, 1000);
+            } else {
+                this._isSockJS = true;
+                this._transport = new this._sockJS(this._sockjsEndpoint(), null, sockjsOptions);
+            }
+        }
+    } else {
+        if (this._sockJS !== null) {
+            this._isSockJS = true;
+            this._transport = new this._sockJS(this._sockjsEndpoint(), null, sockjsOptions);
+        } else {
+            this._transport = new WebSocket(this._rawWebsocketEndpoint());
+        }
+    }
+
     this._transport.onopen = function () {
+        if (self._rawWebsocketTimeout !== null) {
+            clearTimeout(self._rawWebsocketTimeout);
+        }
+
         self._transportClosed = false;
         self._reconnecting = false;
 
-        if (self._useSockJS) {
+        if (self._isSockJS) {
             self._transportName = self._transport.transport;
             self._transport.onheartbeat = function(){
                 self._restartPing();


### PR DESCRIPTION
At moment we have to choose what endpoint to use: raw websocket or SockJS. Raw websocket a bit more performant and now can use compression to reduce bandwidth. So idea was to try raw websocket first and then fallback to SockJS to get all benefits of raw websocket but still have a fallback option.

Here is a pull request implementing it. This mechanism is off by default and can be enabled using boolean option `preferRawWebsocket`. But because of websocket nature there are some caveats here.

There is no websocket abort method in browser. So after we create Websocket object we can't do anything until its `onopen` or `onclose` callbacks are called. Here we use timeout 1000ms by default when connecting to raw websocket. We can't make it suitable for every client - SockJS uses timeout value based on RTT time to `/connection/info` endpoint. We can do the same of course - but it will make things more complex.

In this case when websocket connection timeout fired we try SockJS. Websocket connection can continue to leave in background. If it will be established (i.e. it was Centrifugo timeout) it will be closed as stale after 25 seconds by Centrifugo.

I am not sure is it ok or not - looking for advice. In worst case scenario we will just fallback to SockJS in some cases (when browser supports websocket but connection timed out for some reason - because of slow internet connection or proxy between).

I experimented with Nginx reverse proxy without enabling websocket upgrade in it. In this case `onclose` callback of raw websocket connection called immediately so there are no pending connections in background and we fallback to xhr-streaming.