### PR TITLE
Possibility to set last message ID on first subscribe

### DIFF
--- a/src/centrifuge.js
+++ b/src/centrifuge.js
@@ -1408,7 +1408,7 @@ centrifugeProto.stopAuthBatching = function() {
     }
 };
 
-centrifugeProto.subscribe = function (channel, events) {
+centrifugeProto.subscribe = function (channel, events, lastMessageID) {
     if (arguments.length < 1) {
         throw 'Illegal arguments number: required 1, got ' + arguments.length;
     }
@@ -1417,6 +1417,10 @@ centrifugeProto.subscribe = function (channel, events) {
     }
     if (!this._config.resubscribe && !this.isConnected()) {
         throw 'Can not only subscribe in connected state when resubscribe option is off';
+    }
+
+    if (lastMessageID) {
+        this._lastMessageID[channel] = lastMessageID;
     }
 
     var currentSub = this._getSub(channel);


### PR DESCRIPTION
This pull request contains code to provide last message ID manually on first subscribe to channel to restore missed messages on page open. This way it's possible to save last message ID in localStorage and then restore from that position. I.e. sth like:

```javascript
var lastMessageID = localStorage.getItem("lastMessageID");

var sub = centrifuge.subscribe(channel, handleMessage, lastMessageID);

function handleMessage(message) {
    localStorage.setItem("lastMessageID", message.uid);
    ...
}
```

Not sure that its needed though... Because on first subscribe history should be loaded from backend. But in theory this is interesting. Open for discussion.