### PR TITLE
Add support for custom user-defined transports

### DIFF
--- a/src/centrifuge.js
+++ b/src/centrifuge.js
@@ -177,13 +177,15 @@ function Centrifuge(options) {
         refreshParams: {},
         refreshData: {},
         refreshTransport: "ajax",
+        refreshCallback: null,
         refreshAttempts: null,
         refreshInterval: 3000,
         refreshFailed: null,
         authEndpoint: "/centrifuge/auth/",
         authHeaders: {},
         authParams: {},
-        authTransport: "ajax"
+        authTransport: "ajax",
+        authCallback: null
     };
     if (options) {
         this.configure(options);

--- a/src/centrifuge.js
+++ b/src/centrifuge.js
@@ -735,6 +735,11 @@ centrifugeProto._refresh = function () {
         this._ajax(this._config.refreshEndpoint, this._config.refreshParams, this._config.refreshHeaders, this._config.refreshData, cb);
     } else if (transport === "jsonp") {
         this._jsonp(this._config.refreshEndpoint, this._config.refreshParams, this._config.refreshHeaders, this._config.refreshData, cb);
+    } else if (transport === "custom") {
+        if (!this._config.refreshCallback) {
+            throw 'Missing \'authCallback\' for custom refresh transport';
+        }
+        this._config.refreshCallback(this._config.refreshEndpoint, this._config.refreshParams, this._config.refreshHeaders, data, cb);
     } else {
         throw 'Unknown refresh transport ' + transport;
     }
@@ -1403,6 +1408,11 @@ centrifugeProto.stopAuthBatching = function() {
         this._ajax(this._config.authEndpoint, this._config.authParams, this._config.authHeaders, data, cb);
     } else if (transport === "jsonp") {
         this._jsonp(this._config.authEndpoint, this._config.authParams, this._config.authHeaders, data, cb);
+    } else if (transport === "custom") {
+        if (!this._config.authCallback) {
+            throw 'Missing \'authCallback\' for custom auth transport';
+        }
+        this._config.authCallback(this._config.authEndpoint, this._config.authParams, this._config.authHeaders, data, cb);
     } else {
         throw 'Unknown auth transport ' + transport;
     }


### PR DESCRIPTION
Custom transport can be useful for those who need more control over performing requests to backend.

For example, when using `angular2-token` library, we need to perform requests via service which handles headers, including storing new response headers for consecutive requests.
Custom transport allows to use it like this:
```typescript
export class SocketService {
  private centrifuge;

  constructor(private tokenService: Angular2TokenService) {
     this.centrifuge = new Centrifuge({
       ...
          authTransport: 'custom',
          authCallback: this.authCallback.bind(this)
       ...
     });
  }

  authCallback(endpoint, params, headers, data, callback) {
    this.tokenService.post(endpoint, data).subscribe(
      res => callback(false, res.json(),
      res => callback(true, res.json()
    )
  }
}
```