### PR TITLE
Get centrifugo version on connect

### DIFF
--- a/src/centrifuge.js
+++ b/src/centrifuge.js
@@ -929,6 +929,7 @@ centrifugeProto._connectResponse = function (message) {
 
         this._restartPing();
         this.trigger('connect', [{
+            version: message.body.version,
             client: message.body.client,
             transport: this._transportName,
             latency: this._latency


### PR DESCRIPTION
I want to use the "connect" event to get the version of the Centrifugo in my script for further use.
For example:
```
this._centrifugo.on('connect', (context: any): void => {
    console.log(context.version);
});
```

For now the version property is missing in the "context". However, the version is present in the connection message.
So why not put it in "context"?