### PR TITLE
Prevent message listener duplication for existing subscription

### DIFF
--- a/src/centrifuge.js
+++ b/src/centrifuge.js
@@ -1521,7 +1521,6 @@ centrifugeProto.subscribe = function (channel, events) {
     var currentSub = this._getSub(channel);
 
     if (currentSub !== null) {
-        currentSub._setEvents(events);
         if (currentSub._isUnsubscribed()) {
             currentSub.subscribe();
         }


### PR DESCRIPTION
# Problem
With every unsubscribe() + subscribe() action on the same channel we are getting additional duplicate listener for 'message' event, as a result the callback in `centrifuge.subscribe(channel, callback)` fired multiple times.

# Description
This pull request contains code to fix problem with duplicated message listeners,  we do not need to add listener on each resubscribe since the message listener is already added on `new Sub()`