### PR TITLE
Stop fulfilling rejected error response

### DIFF
--- a/src/centrifuge.js
+++ b/src/centrifuge.js
@@ -555,7 +555,7 @@ export class Centrifuge extends EventEmitter {
       if (rejectCtx.next) {
         rejectCtx.next();
       }
-      return rejectCtx.error;
+      return Promise.reject(rejectCtx.error);
     });
   }
 


### PR DESCRIPTION
fix: Stop fulfilling rejected error response. When RPC has returned error context we should return rejected Promise. Please note that error handler should throw an error or return rejected Promise explicitly.