### PR TITLE
fix TypeError on refresh token with protobuf

### DIFF
--- a/src/protobuf.js
+++ b/src/protobuf.js
@@ -108,7 +108,7 @@ export class ProtobufEncoder {
               type = methodSchema.CONNECT[0];
               break;
             case protobufMethodType.REFRESH:
-              type = methodSchema.REFRESH;
+              type = methodSchema.REFRESH[0];
               break;
             case protobufMethodType.SUBSCRIBE:
               type = methodSchema.SUBSCRIBE[0];


### PR DESCRIPTION
 TypeError: type.encode is not a function at ProtobufEncoder.encodeCommands