### PR TITLE
Support setting subscribe request data

### DIFF
--- a/dist/centrifuge.d.ts
+++ b/dist/centrifuge.d.ts
@@ -210,6 +210,7 @@ declare namespace Centrifuge {
 
     export interface SubscribeOptions {
         since?: StreamPosition;
+        data?: any;
     }
 
     export interface StreamPosition {

--- a/src/centrifuge.js
+++ b/src/centrifuge.js
@@ -1906,19 +1906,13 @@ export class Centrifuge extends EventEmitter {
     if (currentSub !== null) {
       currentSub._setEvents(events);
       if (currentSub._isUnsubscribed()) {
-        currentSub.subscribe();
+        currentSub.subscribe(opts);
       }
       return currentSub;
     }
     const sub = new Subscription(this, channel, events);
     this._subs[channel] = sub;
-    if (opts && opts.since) {
-      this._setSubscribeSince(sub, opts.since);
-    }
-    if (opts && opts.data) {
-      sub._setSubscribeData(opts.data);
-    }
-    sub.subscribe();
+    sub.subscribe(opts);
     return sub;
   };
 }

--- a/src/centrifuge.js
+++ b/src/centrifuge.js
@@ -1136,6 +1136,10 @@ export class Centrifuge extends EventEmitter {
       }
     };
 
+    if (sub._subscribeData) {
+      msg.params.data = sub._subscribeData;
+    }
+
     // If channel name does not start with privateChannelPrefix - then we
     // can just send subscription message to Centrifuge. If channel name
     // starts with privateChannelPrefix - then this is a private channel
@@ -1910,6 +1914,9 @@ export class Centrifuge extends EventEmitter {
     this._subs[channel] = sub;
     if (opts && opts.since) {
       this._setSubscribeSince(sub, opts.since);
+    }
+    if (opts && opts.data) {
+      sub._setSubscribeData(opts.data);
     }
     sub.subscribe();
     return sub;

--- a/src/client.proto.json
+++ b/src/client.proto.json
@@ -349,6 +349,10 @@
                     "offset": {
                       "type": "uint64",
                       "id": 7
+                    },
+                    "data": {
+                      "type": "bytes",
+                      "id": 8
                     }
                   }
                 },

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
-import {Centrifuge} from './centrifuge.js';
+import { Centrifuge } from './centrifuge.js';
 export default Centrifuge;

--- a/src/index_protobuf.js
+++ b/src/index_protobuf.js
@@ -1,2 +1,2 @@
-import {CentrifugeProtobuf} from './protobuf.js';
+import { CentrifugeProtobuf } from './protobuf.js';
 export default CentrifugeProtobuf;

--- a/src/subscription.js
+++ b/src/subscription.js
@@ -27,6 +27,7 @@ export default class Subscription extends EventEmitter {
     this._initializePromise();
     this._promises = {};
     this._promiseId = 0;
+    this._subscribeData = null;
     this.on('error', function (errContext) {
       this._centrifuge._debug('subscription error', errContext);
     });
@@ -51,7 +52,7 @@ export default class Subscription extends EventEmitter {
         this._ready = true;
         reject(err);
       };
-    }).then(function () {}, function () {});
+    }).then(function () { }, function () { });
   };
 
   _setNeedRecover(enabled) {
@@ -198,6 +199,10 @@ export default class Subscription extends EventEmitter {
     return subscribeErrorContext;
   };
 
+  _setSubscribeData(data) {
+    this._subscribeData = data;
+  }
+
   ready(callback, errback) {
     if (this._ready) {
       if (this._isSuccess()) {
@@ -216,6 +221,9 @@ export default class Subscription extends EventEmitter {
     if (opts && opts.since) {
       this._centrifuge._setSubscribeSince(this, opts.since);
     }
+    if (opts && opts.data) {
+      this._setSubscribeData(opts.data);
+    }
     this._centrifuge._subscribe(this);
   };
 
@@ -232,7 +240,7 @@ export default class Subscription extends EventEmitter {
     }
     let subPromise = new Promise((res, rej) => {
       const timeout = setTimeout(function () {
-        rej({'code': 0, 'message': 'timeout'});
+        rej({ 'code': 0, 'message': 'timeout' });
       }, this._centrifuge._config.timeout);
       this._promises[this._nextPromiseId()] = {
         timeout: timeout,

--- a/src/subscription.js
+++ b/src/subscription.js
@@ -214,16 +214,16 @@ export default class Subscription extends EventEmitter {
   };
 
   subscribe(opts) {
-    if (this._status === _STATE_SUCCESS) {
-      return;
-    }
-    this._noResubscribe = false;
     if (opts && opts.since) {
       this._centrifuge._setSubscribeSince(this, opts.since);
     }
     if (opts && opts.data) {
       this._setSubscribeData(opts.data);
     }
+    if (this._status === _STATE_SUCCESS) {
+      return;
+    }
+    this._noResubscribe = false;
     this._centrifuge._subscribe(this);
   };
 

--- a/src/subscription.js
+++ b/src/subscription.js
@@ -214,14 +214,14 @@ export default class Subscription extends EventEmitter {
   };
 
   subscribe(opts) {
+    if (this._status === _STATE_SUCCESS) {
+      return;
+    }
     if (opts && opts.since) {
       this._centrifuge._setSubscribeSince(this, opts.since);
     }
     if (opts && opts.data) {
       this._setSubscribeData(opts.data);
-    }
-    if (this._status === _STATE_SUCCESS) {
-      return;
     }
     this._noResubscribe = false;
     this._centrifuge._subscribe(this);


### PR DESCRIPTION
Support setting `data` to subscription requests.

Server-side implementation is here: https://github.com/centrifugal/centrifuge/pull/216