### PR TITLE
Throw error if no transport configured

### DIFF
--- a/src/centrifuge.js
+++ b/src/centrifuge.js
@@ -452,7 +452,7 @@ export class Centrifuge extends EventEmitter {
     } else {
       if (!this._websocketSupported()) {
         this._debug('No Websocket support and no SockJS configured, can not connect');
-        return;
+        throw new Error('No Websocket support and no SockJS configured, can not connect')
       }
       if (this._config.websocket !== null) {
         this._websocket = this._config.websocket;


### PR DESCRIPTION
It's pretty unobvious in undocumented nodejs environment that you should explicitly configure transport. It's better to fail with error then silently do nothing