### PR TITLE
Do not use importHelpers to avoid using tslib

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "docs": "typedoc --exclude '**/transport_*.ts' --exclude '**/*.test.ts' --exclude '**/*+(utils|json|codes|browser).ts' --excludePrivate --excludeInternal --entryPoints src/*.ts",
     "build": "tsc -p tsconfig.json",
     "build-all": "yarn clean && yarn build && yarn build-browser && yarn build-browser-protobuf",
-    "build-browser": "esbuild src/browser.ts --bundle --minify --sourcemap --outfile=dist/centrifuge.js --define:global=window",
-    "dev": "esbuild src/browser.ts --bundle --outfile=dist/centrifuge.js --define:global=window --servedir=dist/ --serve=2000",
-    "build-browser-protobuf": "esbuild src/protobuf/browser.ts --bundle --minify --sourcemap --outfile=dist/centrifuge.protobuf.js --define:global=window",
-    "dev-protobuf": "esbuild src/protobuf/browser.ts --bundle --outfile=dist/centrifuge.protobuf.js --define:global=window --servedir=dist/ --serve=2000",
+    "build-browser": "esbuild src/browser.ts --bundle --minify --sourcemap --outfile=dist/centrifuge.js",
+    "dev": "esbuild src/browser.ts --bundle --outfile=dist/centrifuge.js --servedir=dist/ --serve=2000",
+    "build-browser-protobuf": "esbuild src/protobuf/browser.ts --bundle --minify --sourcemap --outfile=dist/centrifuge.protobuf.js",
+    "dev-protobuf": "esbuild src/protobuf/browser.ts --bundle --outfile=dist/centrifuge.protobuf.js --servedir=dist/ --serve=2000",
     "proto": "./make-proto"
   },
   "devDependencies": {

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -398,7 +398,7 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
   }
 
   private _configure() {
-    if (!('Promise' in global)) {
+    if (!('Promise' in globalThis)) {
       throw new Error('Promise polyfill required');
     }
 
@@ -555,8 +555,8 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     if (this._config.websocket !== null) {
       websocket = this._config.websocket;
     } else {
-      if (!(typeof global.WebSocket !== 'function' && typeof global.WebSocket !== 'object')) {
-        websocket = global.WebSocket;
+      if (!(typeof globalThis.WebSocket !== 'function' && typeof globalThis.WebSocket !== 'object')) {
+        websocket = globalThis.WebSocket;
       }
     }
 
@@ -564,8 +564,8 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     if (this._config.sockjs !== null) {
       sockjs = this._config.sockjs;
     } else {
-      if (typeof global.SockJS !== 'undefined') {
-        sockjs = global.SockJS;
+      if (typeof globalThis.SockJS !== 'undefined') {
+        sockjs = globalThis.SockJS;
       }
     }
 
@@ -573,8 +573,8 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     if (this._config.eventsource !== null) {
       eventsource = this._config.eventsource;
     } else {
-      if (typeof global.EventSource !== 'undefined') {
-        eventsource = global.EventSource;
+      if (typeof globalThis.EventSource !== 'undefined') {
+        eventsource = globalThis.EventSource;
       }
     }
 
@@ -582,8 +582,8 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     if (this._config.fetch !== null) {
       fetchFunc = this._config.fetch;
     } else {
-      if (typeof global.fetch !== 'undefined') {
-        fetchFunc = global.fetch;
+      if (typeof globalThis.fetch !== 'undefined') {
+        fetchFunc = globalThis.fetch;
       }
     }
 
@@ -591,8 +591,8 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     if (this._config.readableStream !== null) {
       readableStream = this._config.readableStream;
     } else {
-      if (typeof global.ReadableStream !== 'undefined') {
-        readableStream = global.ReadableStream;
+      if (typeof globalThis.ReadableStream !== 'undefined') {
+        readableStream = globalThis.ReadableStream;
       }
     }
 
@@ -636,7 +636,7 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
         } else if (transportName === 'webtransport') {
           this._debug('trying webtransport transport');
           this._transport = new WebtransportTransport(transportEndpoint, {
-            webtransport: global.WebTransport,
+            webtransport: globalThis.WebTransport,
             decoder: this._decoder,
             encoder: this._encoder
           });

--- a/src/transport_sse.ts
+++ b/src/transport_sse.ts
@@ -32,9 +32,9 @@ export class SseTransport {
 
   initialize(_protocol: 'json', callbacks: any, initialData: any) {
     let url: any;
-    if (global && global.document && global.document.baseURI) {
+    if (globalThis && globalThis.document && globalThis.document.baseURI) {
       // Handle case when endpoint is relative, like //example.com/connection/sse
-      url = new URL(this.endpoint, global.document.baseURI);
+      url = new URL(this.endpoint, globalThis.document.baseURI);
     } else {
       url = new URL(this.endpoint);
     }

--- a/src/transport_webtransport.ts
+++ b/src/transport_webtransport.ts
@@ -36,9 +36,9 @@ export class WebtransportTransport {
 
   async initialize(protocol: string, callbacks: any) {
     let url: any;
-    if (global && global.document && global.document.baseURI) {
+    if (globalThis && globalThis.document && globalThis.document.baseURI) {
       // Handle case when endpoint is relative, like //example.com/connection/webtransport
-      url = new URL(this.endpoint, global.document.baseURI);
+      url = new URL(this.endpoint, globalThis.document.baseURI);
     } else {
       url = new URL(this.endpoint);
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,11 +13,11 @@ export function isFunction(value) {
 
 /** @internal */
 export function log(level, args) {
-  if (global.console) {
-    const logger = global.console[level];
+  if (globalThis.console) {
+    const logger = globalThis.console[level];
 
     if (isFunction(logger)) {
-      logger.apply(global.console, args);
+      logger.apply(globalThis.console, args);
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "noUnusedParameters": true /* Report errors on unused parameters. */,
     "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
     "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
-    "importHelpers": true,
+    "importHelpers": false, /* https://github.com/centrifugal/centrifuge-js/issues/193 */
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Relates #193 

It builds Index.js without tslib require:

```javascript
"use strict";
var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
    if (k2 === undefined) k2 = k;
    var desc = Object.getOwnPropertyDescriptor(m, k);
    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
      desc = { enumerable: true, get: function() { return m[k]; } };
    }
    Object.defineProperty(o, k2, desc);
}) : (function(o, m, k, k2) {
    if (k2 === undefined) k2 = k;
    o[k2] = m[k];
}));
var __exportStar = (this && this.__exportStar) || function(m, exports) {
    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
};
Object.defineProperty(exports, "__esModule", { value: true });
exports.Subscription = exports.Centrifuge = void 0;
const centrifuge_1 = require("./centrifuge");
Object.defineProperty(exports, "Centrifuge", { enumerable: true, get: function () { return centrifuge_1.Centrifuge; } });
const subscription_1 = require("./subscription");
Object.defineProperty(exports, "Subscription", { enumerable: true, get: function () { return subscription_1.Subscription; } });
__exportStar(require("./types"), exports);
//# sourceMappingURL=index.js.map
```