### PR TITLE
Fix reconnect on mobile safari

### DIFF
--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -805,14 +805,14 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
       },
       onError: function (e: any) {
         if (self._transportId != transportId) {
-          this._debug('error callback from non-actual transport');
+          self._debug('error callback from non-actual transport');
           return;
         }
         self._debug('transport level error', e);
       },
       onClose: function (closeEvent) {
         if (self._transportId != transportId) {
-          this._debug('close callback from non-actual transport');
+          self._debug('close callback from non-actual transport');
           return;
         }
         self._debug(transport.subName(), 'transport closed');


### PR DESCRIPTION
Looks like mobile Safari does not issue WebSocket close event in some situations - upon going to the flight mode for example.

See https://stackoverflow.com/questions/75869629/ios-websocket-close-and-error-events-not-firing.

This PR tries to workaround this.  