### PR TITLE
setToken method and getData options for Client and Subscription

### DIFF
--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -22,7 +22,7 @@ import {
   TypedEventEmitter, RpcResult, SubscriptionOptions,
   HistoryOptions, HistoryResult, PublishResult,
   PresenceResult, PresenceStatsResult, SubscribedContext,
-  TransportEndpoint, DisconnectOptions,
+  TransportEndpoint,
 } from './types';
 
 import EventEmitter from 'events';
@@ -238,11 +238,12 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
   }
 
   /** disconnect from a server. */
-  disconnect(opts?: DisconnectOptions) {
-    if (opts?.resetConnectionToken === true) {
-      this._token = '';
-    }
+  disconnect() {
     this._disconnect(disconnectedCodes.disconnectCalled, 'disconnect called', false);
+  }
+
+  resetToken() {
+    this._token = '';
   }
 
   /** send asynchronous data to a server (without any response from a server 

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -32,6 +32,7 @@ const defaults: Options = {
   token: '',
   getToken: null,
   data: null,
+  getData: null,
   debug: false,
   name: 'js',
   version: '',
@@ -88,6 +89,7 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
   private _refreshTimeout?: null | ReturnType<typeof setTimeout> = null;
   private _callbacks: Record<number, any>;
   private _token: string;
+  private _data: any;
   private _dispatchPromise: Promise<void>;
   private _serverPing: number;
   private _serverPingTimeout?: null | ReturnType<typeof setTimeout> = null;
@@ -134,6 +136,7 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     this._refreshTimeout = null;
     this._callbacks = {};
     this._token = '';
+    this._data = null;
     this._dispatchPromise = Promise.resolve();
     this._serverPing = 0;
     this._serverPingTimeout = null;
@@ -442,6 +445,10 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
 
     if (this._config.token !== null) {
       this._token = this._config.token;
+    }
+
+    if (this._config.data !== null) {
+      this._data = this._config.data;
     }
 
     this._setFormat('json');
@@ -919,7 +926,17 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     const emptyToken = this._token === '';
     const needTokenRefresh = this._refreshRequired || (emptyToken && this._config.getToken !== null);
     if (!needTokenRefresh) {
-      this._initializeTransport();
+      if (this._config.getData) {
+        this._config.getData().then(function (data: any) {
+          if (!self._isConnecting()) {
+            return;
+          }
+          self._data = data;
+          self._initializeTransport();
+        })
+      } else {
+        this._initializeTransport();
+      }
       return;
     }
 
@@ -935,7 +952,17 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
       }
       self._token = token;
       self._debug('connection token refreshed');
-      self._initializeTransport();
+      if (self._config.getData) {
+        self._config.getData().then(function (data: any) {
+          if (!self._isConnecting()) {
+            return;
+          }
+          self._data = data;
+          self._initializeTransport();
+        })
+      } else {
+        self._initializeTransport();
+      }
     }).catch(function (e) {
       if (!self._isConnecting()) {
         return;
@@ -991,8 +1018,8 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     if (this._token) {
       req.token = this._token;
     }
-    if (this._config.data) {
-      req.data = this._config.data;
+    if (this._data) {
+      req.data = this._data;
     }
     if (this._config.name) {
       req.name = this._config.name;

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -242,8 +242,8 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     this._disconnect(disconnectedCodes.disconnectCalled, 'disconnect called', false);
   }
 
-  resetToken() {
-    this._token = '';
+  setToken(token: string) {
+    this._token = token;
   }
 
   /** send asynchronous data to a server (without any response from a server 

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -924,6 +924,8 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
       return;
     }
 
+    const self = this;
+
     const emptyToken = this._token === '';
     const needTokenRefresh = this._refreshRequired || (emptyToken && this._config.getToken !== null);
     if (!needTokenRefresh) {
@@ -940,8 +942,6 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
       }
       return;
     }
-
-    const self = this;
 
     this._getToken().then(function (token: string) {
       if (!self._isConnecting()) {

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -4,7 +4,8 @@ import { errorCodes, unsubscribedCodes, subscribingCodes, connectingCodes } from
 import {
   HistoryOptions, HistoryResult, PresenceResult, PresenceStatsResult,
   PublishResult, State, SubscriptionEvents, SubscriptionOptions,
-  SubscriptionState, SubscriptionTokenContext, TypedEventEmitter
+  SubscriptionState, SubscriptionTokenContext, TypedEventEmitter,
+  SubscriptionDataContext
 } from './types';
 import { ttlMilliseconds, backoff } from './utils';
 
@@ -28,6 +29,7 @@ export class Subscription extends (EventEmitter as new () => TypedEventEmitter<S
 
   private _token: string;
   private _data: any | null;
+  private _getData: null | ((ctx: SubscriptionDataContext) => Promise<any>);
   private _recoverable: boolean;
   private _positioned: boolean;
   private _joinLeave: boolean;
@@ -43,6 +45,7 @@ export class Subscription extends (EventEmitter as new () => TypedEventEmitter<S
     this._token = '';
     this._getToken = null;
     this._data = null;
+    this._getData = null;
     this._recover = false;
     this._offset = null;
     this._epoch = null;
@@ -504,6 +507,9 @@ export class Subscription extends (EventEmitter as new () => TypedEventEmitter<S
     }
     if (options.data) {
       this._data = options.data;
+    }
+    if (options.getData) {
+      this._getData = options.getData;
     }
     if (options.minResubscribeDelay !== undefined) {
       this._minResubscribeDelay = options.minResubscribeDelay;

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -269,12 +269,13 @@ export class Subscription extends (EventEmitter as new () => TypedEventEmitter<S
     }
 
     const self = this;
+    const getDataCtx = {
+      channel: self.channel
+    };
 
     if (!this._usesToken() || this._token) {
       if (self._getData) {
-        self._getData({
-          channel: self.channel
-        }).then(function (data: any) {
+        self._getData(getDataCtx).then(function (data: any) {
           if (!self._isSubscribing()) {
             return;
           }
@@ -299,9 +300,7 @@ export class Subscription extends (EventEmitter as new () => TypedEventEmitter<S
       }
       self._token = token;
       if (self._getData) {
-        self._getData({
-          channel: self.channel
-        }).then(function (data: any) {
+        self._getData(getDataCtx).then(function (data: any) {
           if (!self._isSubscribing()) {
             return;
           }

--- a/src/types.ts
+++ b/src/types.ts
@@ -309,10 +309,6 @@ export interface HistoryOptions {
   reverse?: boolean;
 }
 
-export interface DisconnectOptions {
-  resetConnectionToken?: boolean;
-}
-
 /** SubscriptionOptions can customize Subscription. */
 export interface SubscriptionOptions {
   /** allows setting initial subscription token (JWT) */

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,8 @@ export interface Options {
   getToken: null | ((ctx: ConnectionTokenContext) => Promise<string>);
   /** data to send to a server with connect command */
   data: any | null;
+  /** allows setting function to get/renew connection data */
+  getData: null | (() => Promise<any>);
   /** name of client - it's not a unique name of each connection, it's sth to identify
    * from where client connected */
   name: string;
@@ -275,6 +277,10 @@ export interface SubscriptionTokenContext {
   channel: string;
 }
 
+export interface SubscriptionDataContext {
+  channel: string;
+}
+
 export interface PublishResult {
 }
 
@@ -315,6 +321,8 @@ export interface SubscriptionOptions {
   getToken: null | ((ctx: ConnectionTokenContext) => Promise<string>);
   /** data to send to a server with subscribe command */
   data: any | null;
+  /** allows setting function to get/renew subscription data */
+  getData: null | (() => Promise<any>);
   /** force recovery on first subscribe from a provided StreamPosition. */
   since: StreamPosition | null;
   /** min delay between resubscribe attempts. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -318,7 +318,7 @@ export interface SubscriptionOptions {
   /** data to send to a server with subscribe command */
   data: any | null;
   /** allows setting function to get/renew subscription data */
-  getData: null | (() => Promise<any>);
+  getData: null | ((ctx: SubscriptionDataContext) => Promise<any>);
   /** force recovery on first subscribe from a provided StreamPosition. */
   since: StreamPosition | null;
   /** min delay between resubscribe attempts. */


### PR DESCRIPTION
Instead of `resetConnectionToken` option for `disconnect` let's add a `setToken` function - which is more generic, may be called separately from disconnect (which is good because someone may want to set token while client already disconnected).

Also, we introduce a possibility to connect with dynamic data without need to re-initialize the client. And subscribe with dynamic data. Dynamic data means that it may be updated during reconnects or resubscriptions - `getData` callback will be called. Previously custom data could only be set during Client or Subscription initialization. 