### PR TITLE
Schedule reconnect from disconnect function instead of transport onClose

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Release on npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-          npm publish --ignore-scripts
+          npm publish --ignore-scripts --tag beta
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "centrifuge",
-  "version": "3.1.2",
+  "version": "3.2.0-beta.0",
   "description": "JavaScript client SDK for bidirectional communication with Centrifugo and Centrifuge-based server from browser, NodeJS and React Native",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -805,14 +805,14 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
       },
       onError: function (e: any) {
         if (self._transportId != transportId) {
-          this._debug('error callback from non-actual transport');
+          self._debug('error callback from non-actual transport');
           return;
         }
         self._debug('transport level error', e);
       },
       onClose: function (closeEvent) {
         if (self._transportId != transportId) {
-          this._debug('close callback from non-actual transport');
+          self._debug('close callback from non-actual transport');
           return;
         }
         self._debug(transport.subName(), 'transport closed');

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -789,13 +789,17 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
 
     this._transportClosed = false;
 
-    const connectTimeout = setTimeout(function () {
+    let connectTimeout: any;
+    connectTimeout = setTimeout(function () {
       transport.close();
     }, this._config.timeout);
 
     this._transport.initialize(this._config.protocol, {
       onOpen: function () {
-        clearTimeout(connectTimeout);
+        if (connectTimeout) {
+          clearTimeout(connectTimeout);
+          connectTimeout = null;
+        }
         if (self._transportId != transportId) {
           self._debug('open callback from non-actual transport');
           transport.close();
@@ -822,6 +826,10 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
         self._debug('transport level error', e);
       },
       onClose: function (closeEvent) {
+        if (connectTimeout) {
+          clearTimeout(connectTimeout);
+          connectTimeout = null;
+        }
         if (self._transportId != transportId) {
           self._debug('close callback from non-actual transport');
           return;

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -1236,6 +1236,7 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
       this._transport = null;
       transport.close(); // Close only after setting this._transport to null to avoid recursion when calling transport close().
       this._transportClosed = true;
+      this._nextTransportId();
     } else {
       this._debug("no transport to close");
     }

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -402,6 +402,10 @@ export class Subscription extends (EventEmitter as new () => TypedEventEmitter<S
       this._clearSubscribedState();
     }
     if (this._isSubscribing()) {
+      if (this._inflight && sendUnsubscribe) {
+        // @ts-ignore – we are hiding some methods from public API autocompletion.
+        this._centrifuge._unsubscribe(this);
+      }
       this._clearSubscribingState();
     }
     if (this._setState(SubscriptionState.Unsubscribed)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,8 @@ export interface Options {
   protocol: 'json' | 'protobuf';
   /** allows enabling debug mode */
   debug: boolean;
+
+  onDebug: null | ((a: any) => void)
   /** allows setting connection token (JWT) */
   token: string | null;
   /** allows setting function to get/refresh connection token */

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,8 +85,6 @@ export interface Options {
   protocol: 'json' | 'protobuf';
   /** allows enabling debug mode */
   debug: boolean;
-
-  onDebug: null | ((a: any) => void)
   /** allows setting connection token (JWT) */
   token: string | null;
   /** allows setting function to get/refresh connection token */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,7 @@ export function isFunction(value) {
 }
 
 /** @internal */
-export function log(level, args) {
+export function log(level: string, args) {
   if (globalThis.console) {
     const logger = globalThis.console[level];
 


### PR DESCRIPTION
To further fix reconnect behaviour on iPhone devices moving reconnect scheduling to disconnect function. This is based on #228   

Also introducing connect timeout which is equal to configuration timeout.