### PR TITLE
feat: make browser builds work in WebWorker/SharedWorker contexts

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -32,6 +32,13 @@ export default [
       {
         file: 'build/index.mjs',
         format: 'es',
+      },
+      {
+        file: 'build/index.iife.js',
+        format: 'iife',
+        name: 'centrifugal',
+        extend: true,
+        intro: 'var self = typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : this;',
       }
     ]
   },
@@ -63,7 +70,7 @@ export default [
       {
         file: 'build/protobuf/index.mjs',
         format: 'es',
-      }
+      },
     ]
   }
 ];

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -70,7 +70,7 @@ export default [
       {
         file: 'build/protobuf/index.mjs',
         format: 'es',
-      },
+      }
     ]
   }
 ];

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -32,13 +32,6 @@ export default [
       {
         file: 'build/index.mjs',
         format: 'es',
-      },
-      {
-        file: 'build/index.iife.js',
-        format: 'iife',
-        name: 'centrifugal',
-        extend: true,
-        intro: 'var self = typeof window !== "undefined" ? window : typeof self !== "undefined" ? self : this;',
       }
     ]
   },

--- a/src/browser.protobuf.ts
+++ b/src/browser.protobuf.ts
@@ -12,4 +12,4 @@ export default class CentrifugeProtobuf extends Centrifuge {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-(window as any).Centrifuge = CentrifugeProtobuf
+(globalThis as any).Centrifuge = CentrifugeProtobuf

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -4,4 +4,4 @@
 import { Centrifuge } from './centrifuge'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-(window as any).Centrifuge = Centrifuge
+(globalThis as any).Centrifuge = Centrifuge


### PR DESCRIPTION
This pull request introduces modifications to the Rollup configuration to support the usage of the `centrifuge-js` library in JavaScript environments that do not have access to the `window` global object, such as SharedWorkers, WebWorkers, and Node.js. The need for this change arises from the limitation observed when the compiled library was strictly bound to the `window` object, restricting its usage in broader contexts where a global `window` object may not be present.

By adjusting the Rollup configuration to conditionally check for the existence of a global object and attach the library accordingly, or export it as a module, this update aims to make `centrifuge-js` more versatile. This enhancement allows developers to leverage the library not only in traditional browser environments but also in multi-threaded web applications using WebWorkers, in SharedWorkers for shared state management between multiple browser contexts, and potentially in server-side applications or tools running on Node.js.

Use Cases:
- **WebWorkers & SharedWorkers**: Enhance performance and user experience in web applications by offloading tasks and managing shared state in a background thread, without blocking the main thread.
- **Node.js**: Although initially designed for client-side use, with minor adjustments or for specific use cases, the library could be utilized server-side to manage WebSocket connections or interface with other systems in a Node.js application.