### PR TITLE
Send commands based on transport state instead of connected state

### DIFF
--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -411,10 +411,6 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     })
   }
 
-  isTransportOpen() {
-    return this._transportIsOpen;
-  }
-
   private _debug(...args: any[]) {
     if (!this._debugEnabled) {
       return;
@@ -1371,7 +1367,7 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
   }
 
   protected _unsubscribe(sub: Subscription) {
-    if (!this.isTransportOpen()) {
+    if (!this._transportIsOpen) {
       return;
     }
     const req = {

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -1207,7 +1207,9 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     if (this._isDisconnected()) {
       return;
     }
-
+    // we mark transport is closed right away, because _clearConnectedState will move subscriptions to subscribing state
+    // if transport will still be open at this time, subscribe frames will be sent to closing transport
+    this._transportIsOpen = false;
     const previousState = this.state;
 
     const ctx = {
@@ -1248,7 +1250,6 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
       transport.close(); // Close only after setting this._transport to null to avoid recursion when calling transport close().
       // Need to mark as closed here, because connect call may be sync called after disconnect,
       // transport onClose callback will not be called yet
-      this._transportIsOpen = false;
       this._transportClosed = true;
       this._nextTransportId();
     } else {

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -254,9 +254,7 @@ export class Subscription extends (EventEmitter as new () => TypedEventEmitter<S
     if (this._setState(SubscriptionState.Subscribing)) {
       this.emit('subscribing', { channel: this.channel, code: code, reason: reason });
     }
-    if (code === subscribingCodes.subscribeCalled) {
-      this._subscribe();
-    }
+    this._subscribe();
   }
 
   private _subscribe(): any {

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -254,7 +254,9 @@ export class Subscription extends (EventEmitter as new () => TypedEventEmitter<S
     if (this._setState(SubscriptionState.Subscribing)) {
       this.emit('subscribing', { channel: this.channel, code: code, reason: reason });
     }
-    this._subscribe();
+    if (code === subscribingCodes.subscribeCalled) {
+      this._subscribe();
+    }
   }
 
   private _subscribe(): any {
@@ -263,7 +265,8 @@ export class Subscription extends (EventEmitter as new () => TypedEventEmitter<S
 
     // need to check transport readiness here, because there's no point for calling getData or getToken
     // if transport is not ready yet
-    if (!this._centrifuge.isTransportOpen()) {
+    // @ts-ignore – we are hiding some symbols from public API autocompletion.
+    if (!this._centrifuge._transportIsOpen) {
       // @ts-ignore – we are hiding some symbols from public API autocompletion.
       this._centrifuge._debug('delay subscribe on', this.channel, 'till connected');
       // subscribe will be called later automatically.
@@ -334,7 +337,8 @@ export class Subscription extends (EventEmitter as new () => TypedEventEmitter<S
   private _sendSubscribe(token: string): any {
     // we also need to check for transport state before sending subscription
     // because it may change for subscription with side effects (getData, getToken options)
-    if (!this._centrifuge.isTransportOpen()) {
+    // @ts-ignore – we are hiding some symbols from public API autocompletion.
+    if (!this._centrifuge._transportIsOpen) {
       return null;
     }
     const channel = this.channel;


### PR DESCRIPTION
Change sending commands logic, rely on transport state instead of client connected state,

Fixes missing subscribe frames bug for unsubscribes, that have been called between transport open and connected frame response for server. 

Also it will allow to send subscribe requests after transport has been opened without waiting for response from server.

Notes: 

Removed `optimistic` flag from Subscription, it does not make sense, because we can just rely on transport state.

Removed `skipSending` flag from Subscription, it's not longer required, because it have been used only for sending optimistic subs in `emulation` transport and this optimistic subs are removed right now, because they would require implementation of queue of unsubscribe frames, which would lead to way more complicated logic. But it will be easy to return, if will be required later.

Also I have made a public method in centrifuge, that indicates that transport is ready, so it can be used inside subscription without `@ts-ignore`, but I think it would be good idea to move all logic of skipping commands sending into Centrifuge client and remove early returns from Subscription.

P.S. I have spent some time trying to properly configure centrifugo server instance to be able to run all tests locally, what do you think about adding docker-compose file + config.json to this repo?