### PR TITLE
Synchronize subscribe with unsubscribe to properly work in emulation case

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,13 +519,15 @@ sub.publish({"input": "hello world"}).then(function() {
 You can call `unsubscribe` method to unsubscribe from a channel:
 
 ```javascript
-sub.unsubscribe();
+await sub.unsubscribe();
 ```
 
-**Important thing to know** is that unsubscribing from subscription does not remove event handlers you already set to that Subscription object. This allows to simply subscribe to channel again later calling `.subscribe()` method of subscription (see below). But there are cases when your code structured in a way that you need to remove event handlers after unsubscribe **to prevent them be executed twice** in the future. To do this remove event listeners explicitly after calling `unsubscribe()`:
+Note, `sub.unsubscribe()` is asynchronous and may be used without `await`, but in some cases it may be very important to await it before calling subscribe again. For example, this becomes important when using HTTP-based fallback transports and quick unsubscribe/subscribe calls – awaiting unsubscribe call allows to properly synchronize unsubscribe and subscribe requests (to avoid subscribe request be processed before unsubscribe request on the server). To WebSocket and Webtransport this does not apply - since requests go through a direct connection to a server instance that holds connection.
+
+**Important thing to mention** is that unsubscribing from subscription does not remove event handlers you already set to that Subscription object. This allows to simply subscribe to channel again later calling `.subscribe()` method of subscription (see below). But there are cases when your code structured in a way that you need to remove event handlers after unsubscribe **to prevent them be executed twice** in the future. To do this remove event listeners explicitly after calling `unsubscribe()`:
 
 ```javascript
-sub.unsubscribe();
+await sub.unsubscribe();
 sub.removeAllListeners();
 ```
 

--- a/README.md
+++ b/README.md
@@ -519,15 +519,13 @@ sub.publish({"input": "hello world"}).then(function() {
 You can call `unsubscribe` method to unsubscribe from a channel:
 
 ```javascript
-await sub.unsubscribe();
+sub.unsubscribe();
 ```
-
-Note, `sub.unsubscribe()` is asynchronous and may be used without `await`, but in some cases it may be very important to await it before calling subscribe again. For example, this becomes important when using HTTP-based fallback transports and quick unsubscribe/subscribe calls – awaiting unsubscribe call allows to properly synchronize unsubscribe and subscribe requests (to avoid subscribe request be processed before unsubscribe request on the server). To WebSocket and Webtransport this does not apply - since requests go through a direct connection to a server instance that holds connection.
 
 **Important thing to mention** is that unsubscribing from subscription does not remove event handlers you already set to that Subscription object. This allows to simply subscribe to channel again later calling `.subscribe()` method of subscription (see below). But there are cases when your code structured in a way that you need to remove event handlers after unsubscribe **to prevent them be executed twice** in the future. To do this remove event listeners explicitly after calling `unsubscribe()`:
 
 ```javascript
-await sub.unsubscribe();
+sub.unsubscribe();
 sub.removeAllListeners();
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   centrifugo:
-    image: centrifugo/centrifugo:v5
+    image: centrifugo/centrifugo:v5.4.0
     command:
       - centrifugo
     ports:
@@ -12,3 +12,5 @@ services:
       - CENTRIFUGO_HTTP_STREAM=true
       - CENTRIFUGO_SSE=true
       - CENTRIFUGO_PRESENCE=true
+      - CENTRIFUGO_CLIENT_CONCURRENCY=8
+      - CENTRIFUGO_LOG_LEVEL=debug

--- a/src/centrifuge.test.ts
+++ b/src/centrifuge.test.ts
@@ -360,11 +360,24 @@ test.each(transportCases)("%s: subscribe and unsubscribe loop", async (transport
   })
 
   for (let index = 0; index < 10; index++) {
-    sub.subscribe();
-    sub.unsubscribe();
+    await sub.subscribe();
+    await sub.unsubscribe();
   }
   expect(sub.state).toBe(SubscriptionState.Unsubscribed);
   await unsubscribedPromise;
+
+  await sub.subscribe()
+  const presenceStats = await sub.presenceStats();
+  expect(presenceStats.numClients).toBe(1)
+  expect(presenceStats.numUsers).toBe(1);
+  const presence = await sub.presence();
+  expect(Object.keys(presence.clients).length).toBe(1)
+  await sub.unsubscribe()
+  const presenceStats2 = await c.presenceStats('test');
+  expect(presenceStats2.numClients).toBe(0)
+  expect(presenceStats2.numUsers).toBe(0);
+  const presence2 = await c.presence('test');
+  expect(Object.keys(presence2.clients).length).toBe(0)
 
   let disconnectCalled: any;
   const disconnectedPromise = new Promise<DisconnectedContext>((resolve, _) => {

--- a/src/centrifuge.test.ts
+++ b/src/centrifuge.test.ts
@@ -360,13 +360,13 @@ test.each(transportCases)("%s: subscribe and unsubscribe loop", async (transport
   })
 
   for (let index = 0; index < 10; index++) {
-    await sub.subscribe();
-    await sub.unsubscribe();
+    sub.subscribe();
+    sub.unsubscribe();
   }
   expect(sub.state).toBe(SubscriptionState.Unsubscribed);
   await unsubscribedPromise;
 
-  await sub.subscribe()
+  sub.subscribe()
   const presenceStats = await sub.presenceStats();
   expect(presenceStats.numClients).toBe(1)
   expect(presenceStats.numUsers).toBe(1);

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -118,9 +118,8 @@ export class Subscription extends (EventEmitter as new () => TypedEventEmitter<S
   }
 
   /** unsubscribe from a channel, keeping position state.*/
-  async unsubscribe() {
+  unsubscribe() {
     this._unsubPromise = this._setUnsubscribed(unsubscribedCodes.unsubscribeCalled, 'unsubscribe called', true);
-    return this._unsubPromise;
   }
 
   /** publish data to a channel.*/

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -115,7 +115,9 @@ export class Subscription extends (EventEmitter as new () => TypedEventEmitter<S
     this._setSubscribing(subscribingCodes.subscribeCalled, 'subscribe called');
     try {
       await this.ready();
-    } catch (e) {}
+    } catch (e) {
+      // do nothing.
+    }
   }
 
   /** unsubscribe from a channel, keeping position state.*/

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -266,7 +266,10 @@ export class Subscription extends (EventEmitter as new () => TypedEventEmitter<S
     if (this._setState(SubscriptionState.Subscribing)) {
       this.emit('subscribing', { channel: this.channel, code: code, reason: reason });
     }
-    await this._unsubPromise;
+    // @ts-ignore – for performance reasons only await _unsubPromise for emulution case where it's required.
+    if (this._centrifuge._transport && this._centrifuge._transport.emulation()) {
+      await this._unsubPromise;
+    }
     if (!this._isSubscribing()) {
       return;
     }


### PR DESCRIPTION
In some cases like using HTTP emulation fallbacks it's important to synchronize unsubscribe with subscribe calls. Adding an internal unsubscribe promise helps to solve it.