### PR TITLE
Add test case to reproduce subscription token fetch bug.

### DIFF
--- a/src/centrifuge.test.ts
+++ b/src/centrifuge.test.ts
@@ -47,7 +47,7 @@ test.each(transportCases)("%s: subscription:getToken should be called once", asy
   }], {
      // @ts-ignore unused param
      getToken: async function (ctx: any): Promise<string> {
-       await sleep(Math.random() * 100);
+       await sleep(100);
        return "";
      },
       websocket: WebSocket,
@@ -65,7 +65,7 @@ test.each(transportCases)("%s: subscription:getToken should be called once", asy
   const sub = c.newSubscription('test1', {
     getToken: async function () {
       counter++;
-      await sleep(Math.random() * 40);
+      await sleep(40);
       return token;
     }
   });

--- a/src/centrifuge.test.ts
+++ b/src/centrifuge.test.ts
@@ -40,14 +40,13 @@ const websocketOnly = [
 ]
 
 test.each(transportCases)("%s: subscription:getToken should be called once", async (transport, endpoint) => {
+  const sleep = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
   const c = new Centrifuge([{
     transport: transport as TransportName,
     endpoint: endpoint,
   }], {
-
-    // @ts-ignore unused param
+     // @ts-ignore unused param
      getToken: async function (ctx: any): Promise<string> {
-       const sleep = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
        await sleep(Math.random() * 100);
        return "";
      },
@@ -61,7 +60,6 @@ test.each(transportCases)("%s: subscription:getToken should be called once", asy
 
   c.connect();
 
-  const sleep = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
   let counter = 0;
   const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3Mzc1MzIzNDgsImNoYW5uZWwiOiJ0ZXN0MSJ9.eqPQxbBtyYxL8Hvbkm-P6aH7chUsSG_EMWe-rTwF_HI";
   const sub = c.newSubscription('test1', {
@@ -73,7 +71,8 @@ test.each(transportCases)("%s: subscription:getToken should be called once", asy
   });
 
   sub.subscribe();
-  await sub.ready(200);
+  await sub.ready(5000);
+  expect(sub.state).toBe(SubscriptionState.Subscribed);
   expect(counter).toEqual(1);
 });
 


### PR DESCRIPTION
Adds a test to reproduce a bug where initiating a subscription (with getToken) before connection token (getToken) completes causes multiple subscription tokens fetches. 

This is one way to reproduce the issue, but there may be more scenarios.