### PR TITLE
Bbetter error message when WS is not supported

### DIFF
--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -677,7 +677,7 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
           websocket: websocket
         });
         if (!this._transport.supported()) {
-          throw new Error('WebSocket not available');
+          throw new Error('WebSocket constructor not found, make sure it is available globally or passed as a dependency in Centrifuge options');
         }
       }
     } else {


### PR DESCRIPTION
Turned out current message may be misleading when WS is not connecting on NodeJS