### PR TITLE
Remove no-cache to allow caching preflight

### DIFF
--- a/src/transport_http_stream.ts
+++ b/src/transport_http_stream.ts
@@ -210,7 +210,6 @@ export class HttpStreamTransport {
       body: body,
       mode: 'cors',
       credentials: 'same-origin',
-      cache: 'no-cache'
     }
     fetchFunc(this.options.emulationEndpoint, fetchOptions);
   }

--- a/src/transport_sse.ts
+++ b/src/transport_sse.ts
@@ -95,7 +95,6 @@ export class SseTransport {
       body: body,
       mode: 'cors',
       credentials: 'same-origin',
-      cache: 'no-cache'
     }
     fetchFunc(this.options.emulationEndpoint, fetchOptions);
   }


### PR DESCRIPTION
With this change adding `Access-Control-Max-Age` header to preflight OPTIONS response helps to avoid preflight requests for every cross-domain emulation request.