### PR TITLE
Proper UnauthorizedError on missing getToken, more tests

### DIFF
--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -1308,8 +1308,7 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
           message: 'token expired but no getToken function set in the configuration'
         }
       });
-      throw new UnauthorizedError('');
-      // return Promise.reject(new UnauthorizedError(''));
+      return Promise.reject(new UnauthorizedError(''));
     }
     return this._config.getToken({});
   }

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -1309,6 +1309,7 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
         }
       });
       throw new UnauthorizedError('');
+      // return Promise.reject(new UnauthorizedError(''));
     }
     return this._config.getToken({});
   }

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -693,7 +693,7 @@ export class Subscription extends (EventEmitter as new () => TypedEventEmitter<S
           message: 'provide a function to get channel subscription token'
         }
       });
-      throw new UnauthorizedError('');
+      return Promise.reject(new UnauthorizedError(''));
     }
     return getToken(ctx);
   }


### PR DESCRIPTION
Fixes bug outlined in https://github.com/centrifugal/centrifuge-js/issues/310#issuecomment-2725232684

Also added a couple of test cases to check throwing still works properly in getToken implementation.