### PR TITLE
docs: fix `removeSubscription`

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ getSubscription returns `Subscription` if it's registered in the internal regist
 
 `removeSubscription(sub: Subscription | null)`
 
-removeSubscription allows removing Subcription from the internal registry. Subscrption must be in unsubscribed state.
+removeSubscription allows removing Subcription from the internal registry.
 
 ### subscriptions
 

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -185,8 +185,7 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     return this._getSub(channel);
   }
 
-  /** removeSubscription allows removing Subcription from the internal registry. Subscrption 
-   * must be in unsubscribed state. */
+  /** removeSubscription allows removing Subcription from the internal registry. */
   removeSubscription(sub: Subscription | null) {
     if (!sub) {
       return;


### PR DESCRIPTION
It seems that `removeSubscription` does unsubscribe under the hood, provided the state isn't already `Unsubscribed` (which I found very handy, tbh).

[See ref](https://github.com/centrifugal/centrifuge-js/blob/70db996f351f75707cda75f185c69a0b7d5f8f82/src/centrifuge.ts#L194-L196).

