### PR TITLE
Add codecs benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ node_modules
 
 build/
 dist/
+proto/

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "prepare": "npm run build-all",
     "lint": "eslint src/ --ext .js,.jsx,.ts,.tsx",
     "test": "jest --detectOpenHandles --verbose",
+    "bench": "jest src/codec.bench.test.ts",
     "clean": "rm -rf dist build package",
     "ts-node": "ts-node",
     "docs": "typedoc --exclude '**/transport_*.ts' --exclude '**/*.test.ts' --exclude '**/*+(utils|json|protobuf.codec|codes|browser).ts' --excludePrivate --excludeInternal --entryPoints src/*.ts",

--- a/src/codec.bench.test.ts
+++ b/src/codec.bench.test.ts
@@ -1,0 +1,86 @@
+import { ProtobufCodec } from './protobuf.codec';
+import { JsonCodec } from './json';
+import { performance } from 'perf_hooks';
+
+const BENCH_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3Mzc1MzIzNDgsImNoYW5uZWwiOiJ0ZXN0MSJ9.eqPQxbBtyYxL8Hvbkm-P6aH7chUsSG_EMWe-rTwF_HI';
+
+const createFixedCommands = (): any[] => [
+  { id: 1, connect: { token: BENCH_TOKEN } },
+  { id: 2, subscribe: { channel: 'channel1', token: BENCH_TOKEN } },
+  { id: 3, subscribe: { channel: 'channel2', token: BENCH_TOKEN } },
+  { id: 4, subscribe: { channel: 'channel3', token: BENCH_TOKEN } },
+  { id: 5, subscribe: { channel: 'channel4', token: BENCH_TOKEN } }
+];
+
+const runNIterations = (n: number, fn: () => void): { totalMs: number, avgMicro: number } => {
+  const start = performance.now();
+  for (let i = 0; i < n; i++) {
+    fn();
+  }
+  const totalMs = performance.now() - start;
+  return {
+    totalMs,
+    avgMicro: (totalMs * 1000) / n
+  };
+};
+
+describe('Codec benchmark (Protobuf vs JSON)', () => {
+  const N = 10000;
+  const commands = createFixedCommands();
+
+  describe('ProtobufCodec', () => {
+    const codec = new ProtobufCodec();
+    let encoded: Uint8Array;
+    let lastDecoded: any;
+
+    it(`encodeCommands – ${N} runs`, () => {
+      const { totalMs, avgMicro } = runNIterations(N, () => {
+        encoded = codec.encodeCommands(commands);
+      });
+
+      console.log(`🔹 Protobuf Encode: ${N} runs — Total: ${totalMs.toFixed(2)} ms, Avg: ${avgMicro.toFixed(2)} µs/op`);
+      expect(encoded).toBeInstanceOf(Uint8Array);
+    });
+
+    it(`decodeReplies – ${N} runs`, () => {
+      expect(encoded).toBeDefined();
+
+      try {
+        const { totalMs, avgMicro } = runNIterations(N, () => {
+          lastDecoded = codec.decodeReplies(encoded);
+        });
+
+        console.log(`🔹 Protobuf Decode: ${N} runs — Total: ${totalMs.toFixed(2)} ms, Avg: ${avgMicro.toFixed(2)} µs/op`);
+        expect(Array.isArray(lastDecoded)).toBe(true);
+      } catch (err: any) {
+        console.warn('⚠️  Protobuf decoding failed:', err.message);
+      }
+    });
+  });
+
+  describe('JsonCodec', () => {
+    const codec = new JsonCodec();
+    let encoded: string;
+    let lastDecoded: any;
+
+    it(`encodeCommands – ${N} runs`, () => {
+      const { totalMs, avgMicro } = runNIterations(N, () => {
+        encoded = codec.encodeCommands(commands);
+      });
+
+      console.log(`🔸 JSON Encode: ${N} runs — Total: ${totalMs.toFixed(2)} ms, Avg: ${avgMicro.toFixed(2)} µs/op`);
+      expect(typeof encoded).toBe('string');
+    });
+
+    it(`decodeReplies – ${N} runs`, () => {
+      expect(encoded).toBeDefined();
+
+      const { totalMs, avgMicro } = runNIterations(N, () => {
+        lastDecoded = codec.decodeReplies(encoded);
+      });
+
+      console.log(`🔸 JSON Decode: ${N} runs — Total: ${totalMs.toFixed(2)} ms, Avg: ${avgMicro.toFixed(2)} µs/op`);
+      expect(Array.isArray(lastDecoded)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Local run:

```
❯ yarn bench
yarn run v1.22.19
$ jest src/codec.bench.test.ts
  console.log
    🔹 Protobuf Encode: 10000 runs — Total: 59.81 ms, Avg: 5.98 µs/op

      at Object.<anonymous> (src/codec.bench.test.ts:36:21)

  console.log
    🔹 Protobuf Decode: 10000 runs — Total: 74.58 ms, Avg: 7.46 µs/op

      at Object.<anonymous> (src/codec.bench.test.ts:45:25)

  console.log
    🔸 JSON Encode: 10000 runs — Total: 35.69 ms, Avg: 3.57 µs/op

      at Object.<anonymous> (src/codec.bench.test.ts:61:21)

  console.log
    🔸 JSON Decode: 10000 runs — Total: 33.27 ms, Avg: 3.33 µs/op

      at Object.<anonymous> (src/codec.bench.test.ts:69:21)

 PASS  src/codec.bench.test.ts
  Codec benchmark (Protobuf vs JSON)
    ProtobufCodec
      ✓ encodeCommands – 10000 runs (70 ms)
      ✓ decodeReplies – 10000 runs (76 ms)
    JsonCodec
      ✓ encodeCommands – 10000 runs (37 ms)
      ✓ decodeReplies – 10000 runs (35 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        0.891 s
Ran all test suites matching /src\/codec.bench.test.ts/i.
✨  Done in 1.80s.
❯ yarn bench
yarn run v1.22.19
$ jest src/codec.bench.test.ts
  console.log
    🔹 Protobuf Encode: 10000 runs — Total: 59.92 ms, Avg: 5.99 µs/op

      at Object.<anonymous> (src/codec.bench.test.ts:36:21)

  console.log
    🔹 Protobuf Decode: 10000 runs — Total: 74.37 ms, Avg: 7.44 µs/op

      at Object.<anonymous> (src/codec.bench.test.ts:45:25)

  console.log
    🔸 JSON Encode: 10000 runs — Total: 35.33 ms, Avg: 3.53 µs/op

      at Object.<anonymous> (src/codec.bench.test.ts:61:21)

  console.log
    🔸 JSON Decode: 10000 runs — Total: 34.86 ms, Avg: 3.49 µs/op

      at Object.<anonymous> (src/codec.bench.test.ts:69:21)

 PASS  src/codec.bench.test.ts
  Codec benchmark (Protobuf vs JSON)
    ProtobufCodec
      ✓ encodeCommands – 10000 runs (71 ms)
      ✓ decodeReplies – 10000 runs (76 ms)
    JsonCodec
      ✓ encodeCommands – 10000 runs (36 ms)
      ✓ decodeReplies – 10000 runs (37 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        0.888 s, estimated 1 s
```