### PR TITLE
add hasRecoveredPublications field to SubscribedContext

### DIFF
--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -1598,7 +1598,8 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
       positioned: false,
       recoverable: false,
       wasRecovering: false,
-      recovered: false
+      recovered: false,
+      hasRecoveredPublications: false,
     };
     if (result.recovered) {
       ctx.recovered = true;
@@ -1625,6 +1626,9 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
         'offset': offset,
         'epoch': epoch
       };
+    }
+    if (Array.isArray(result.publications) && result.publications.length > 0) {
+      ctx.hasRecoveredPublications = true;
     }
     if (result.data) {
       ctx.data = result.data;

--- a/src/types.ts
+++ b/src/types.ts
@@ -249,6 +249,10 @@ export interface SubscribedContext {
   streamPosition?: StreamPosition;
   wasRecovering: boolean;
   recovered: boolean;
+  // whether or not successfully recovered subscription has received missed publications
+  // warning: must be used for metrics/logs purposes only
+  // since publications are processed after 'subscribed' event
+  hasRecoveredPublications: boolean;
   data?: any;
 }
 


### PR DESCRIPTION
Implementation of approach suggested in #325 

SubscribedContext now has `hasRecoveredPublications: boolean` field that shows if subscribe response with `recovered: true` had > 0 publications to recover.