### PR TITLE
Fix decode benchmark

### DIFF
--- a/src/codec.bench.test.ts
+++ b/src/codec.bench.test.ts
@@ -1,15 +1,32 @@
 import { ProtobufCodec } from './protobuf.codec';
 import { JsonCodec } from './json';
 import { performance } from 'perf_hooks';
+import { centrifugal } from './client_proto';
 
 const BENCH_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3Mzc1MzIzNDgsImNoYW5uZWwiOiJ0ZXN0MSJ9.eqPQxbBtyYxL8Hvbkm-P6aH7chUsSG_EMWe-rTwF_HI';
 
-const createFixedCommands = (): any[] => [
+const createFixedCommands = (): centrifugal.centrifuge.protocol.Command[] => [
   { id: 1, connect: { token: BENCH_TOKEN } },
   { id: 2, subscribe: { channel: 'channel1', token: BENCH_TOKEN } },
   { id: 3, subscribe: { channel: 'channel2', token: BENCH_TOKEN } },
   { id: 4, subscribe: { channel: 'channel3', token: BENCH_TOKEN } },
   { id: 5, subscribe: { channel: 'channel4', token: BENCH_TOKEN } }
+];
+
+const createFixedReplies = (): centrifugal.centrifuge.protocol.Reply[] => [
+  {
+    id: 1,
+    connect: {
+      client: 'test-client',
+      version: 'v4.0.0',
+      expires: true,
+      ttl: 60
+    },
+  },
+  {id: 2, subscribe: {}},
+  {id: 3, subscribe: {}},
+  {id: 4, subscribe: {}},
+  {id: 5, subscribe: {}}
 ];
 
 const runNIterations = (n: number, fn: () => void): { totalMs: number, avgMicro: number } => {
@@ -27,41 +44,36 @@ const runNIterations = (n: number, fn: () => void): { totalMs: number, avgMicro:
 describe('Codec benchmark (Protobuf vs JSON)', () => {
   const N = 10000;
   const commands = createFixedCommands();
+  const replies = createFixedReplies();
 
   describe('ProtobufCodec', () => {
     const codec = new ProtobufCodec();
     let encoded: Uint8Array;
-    let lastDecoded: any;
+    let decoded: any[];
+    let encodedReplies = codec.encodeReplies(replies);
 
     it(`encodeCommands – ${N} runs`, () => {
       const { totalMs, avgMicro } = runNIterations(N, () => {
         encoded = codec.encodeCommands(commands);
       });
-
       console.log(`🔹 Protobuf Encode: ${N} runs — Total: ${totalMs.toFixed(2)} ms, Avg: ${avgMicro.toFixed(2)} µs/op`);
       expect(encoded).toBeInstanceOf(Uint8Array);
     });
 
     it(`decodeReplies – ${N} runs`, () => {
-      expect(encoded).toBeDefined();
-
-      try {
-        const { totalMs, avgMicro } = runNIterations(N, () => {
-          lastDecoded = codec.decodeReplies(encoded);
-        });
-
-        console.log(`🔹 Protobuf Decode: ${N} runs — Total: ${totalMs.toFixed(2)} ms, Avg: ${avgMicro.toFixed(2)} µs/op`);
-        expect(Array.isArray(lastDecoded)).toBe(true);
-      } catch (err: any) {
-        console.warn('⚠️  Protobuf decoding failed:', err.message);
-      }
+      const { totalMs, avgMicro } = runNIterations(N, () => {
+        decoded = codec.decodeReplies(encodedReplies);
+      });
+      console.log(`🔹 Protobuf Decode: ${N} runs — Total: ${totalMs.toFixed(2)} ms, Avg: ${avgMicro.toFixed(2)} µs/op`);
+      expect(Array.isArray(decoded)).toBe(true);
     });
   });
 
   describe('JsonCodec', () => {
     const codec = new JsonCodec();
     let encoded: string;
-    let lastDecoded: any;
+    let decoded: any;
+    let encodedReplies = JSON.stringify(replies);
 
     it(`encodeCommands – ${N} runs`, () => {
       const { totalMs, avgMicro } = runNIterations(N, () => {
@@ -73,14 +85,12 @@ describe('Codec benchmark (Protobuf vs JSON)', () => {
     });
 
     it(`decodeReplies – ${N} runs`, () => {
-      expect(encoded).toBeDefined();
-
       const { totalMs, avgMicro } = runNIterations(N, () => {
-        lastDecoded = codec.decodeReplies(encoded);
+        decoded = codec.decodeReplies(encodedReplies);
       });
 
       console.log(`🔸 JSON Decode: ${N} runs — Total: ${totalMs.toFixed(2)} ms, Avg: ${avgMicro.toFixed(2)} µs/op`);
-      expect(Array.isArray(lastDecoded)).toBe(true);
+      expect(Array.isArray(decoded)).toBe(true);
     });
   });
 });

--- a/src/codec.bench.test.ts
+++ b/src/codec.bench.test.ts
@@ -50,7 +50,7 @@ describe('Codec benchmark (Protobuf vs JSON)', () => {
     const codec = new ProtobufCodec();
     let encoded: Uint8Array;
     let decoded: any[];
-    let encodedReplies = codec.encodeReplies(replies);
+    const encodedReplies = codec.encodeReplies(replies);
 
     it(`encodeCommands – ${N} runs`, () => {
       const { totalMs, avgMicro } = runNIterations(N, () => {
@@ -73,7 +73,7 @@ describe('Codec benchmark (Protobuf vs JSON)', () => {
     const codec = new JsonCodec();
     let encoded: string;
     let decoded: any;
-    let encodedReplies = JSON.stringify(replies);
+    const encodedReplies = JSON.stringify(replies);
 
     it(`encodeCommands – ${N} runs`, () => {
       const { totalMs, avgMicro } = runNIterations(N, () => {

--- a/src/protobuf.codec.ts
+++ b/src/protobuf.codec.ts
@@ -27,6 +27,15 @@ export class ProtobufCodec {
     return writer.finish();
   }
 
+  encodeReplies(replies: centrifugal.centrifuge.protocol.IReply[]): Uint8Array {
+    const writer = Writer.create();
+    for (const reply of replies) {
+      writer.fork();
+      Reply.encodeDelimited(reply, writer);
+    }
+    return writer.finish();
+  }
+
   decodeReplies(data: ArrayBuffer | Uint8Array): centrifugal.centrifuge.protocol.Reply[] {
     const replies: centrifugal.centrifuge.protocol.Reply[] = [];
     const reader = Reader.create(new Uint8Array(data));
@@ -35,6 +44,16 @@ export class ProtobufCodec {
       replies.push(reply);
     }
     return replies;
+  }
+
+  decodeCommands(data: ArrayBuffer | Uint8Array): centrifugal.centrifuge.protocol.Command[] {
+    const commands: centrifugal.centrifuge.protocol.Command[] = [];
+    const reader = Reader.create(new Uint8Array(data));
+    while (reader.pos < reader.len) {
+      const reply = Command.decodeDelimited(reader);
+      commands.push(reply);
+    }
+    return commands;
   }
 
   decodeReply(data: ArrayBuffer | Uint8Array): { ok: true; pos: number } | { ok: false } {


### PR DESCRIPTION
Previously benchmark decoded encoded commands which is incorrect. Use a fixed set of replies for decoding bench.