### PR TITLE
add setData methods to client and subscription

### DIFF
--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -255,6 +255,13 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     this._token = token;
   }
 
+  /** setData allows setting connection data. This only affects the next connection attempt,
+   * not the current one. Note that if getData callback is configured, it will override
+   * this value during reconnects. */
+  setData(data: any) {
+    this._data = data;
+  }
+
   /** setHeaders allows setting connection emulated headers. */
   setHeaders(headers: { [key: string]: string }) {
     this._config.headers = headers;

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -157,6 +157,12 @@ export class Subscription extends (EventEmitter as new () => TypedEventEmitter<S
     this._tagsFilter = tagsFilter;
   }
 
+  /** setData allows setting subscription data. This only applied on the next subscription attempt,
+   * Note that if getData callback is configured, it will override this value during resubscriptions. */
+  setData(data: any) {
+    this._data = data;
+  }
+
   private _methodCall(): Promise<void> {
     if (this._isSubscribed()) {
       return Promise.resolve();

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,11 +100,13 @@ export interface Options {
   debug: boolean;
   /** allows setting initial connection token (JWT) */
   token: string;
-  /** allows setting function to get/refresh connection token */
+  /** allows setting function to get/refresh connection token,
+   * this will only be called when new token needed, not on every reconnect. */
   getToken: null | ((ctx: ConnectionTokenContext) => Promise<string>);
   /** data to send to a server with connect command */
   data: any | null;
-  /** allows setting function to get/renew connection data */
+  /** allows setting function to get/renew connection data (called upon reconnects).
+   * In many cases you may prefer using setData method of Centrifuge Client instead. */
   getData: null | (() => Promise<any>);
   /** name of client - it's not a unique name of each connection, it's sth to identify
    * from where client connected */
@@ -362,11 +364,13 @@ export interface HistoryOptions {
 export interface SubscriptionOptions {
   /** allows setting initial subscription token (JWT) */
   token: string;
-  /** allows setting function to get/refresh subscription token */
+  /** allows setting function to get/refresh subscription token,
+   * this will only be called when new token needed, not on every resubscribe. */
   getToken: null | ((ctx: SubscriptionTokenContext) => Promise<string>);
   /** data to send to a server with subscribe command */
   data: any | null;
-  /** allows setting function to get/renew subscription data */
+  /** allows setting function to get/renew subscription data (during resubscriptions).
+   * In many cases you may prefer using setData method of Subscription instead. */
   getData: null | ((ctx: SubscriptionDataContext) => Promise<any>);
   /** force recovery on first subscribe from a provided StreamPosition. */
   since: Partial<StreamPosition> | null;


### PR DESCRIPTION
Add `setData` methods to Centrifuge client and Subscription. This method may be called to update protocol `data` for the connection/subscription after initialization (initial `data` may be set in client or subscription options).

Relates #333 