### PR TITLE
Fix bug with instanceof of Array

### DIFF
--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -461,7 +461,7 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
 
     if (typeof this._endpoint === 'string') {
       // Single address.
-    } else if (typeof this._endpoint === 'object' && this._endpoint instanceof Array) {
+    } else if (Array.isArray(this._endpoint)) {
       this._transports = this._endpoint;
       this._emulation = true;
       for (const i in this._transports) {


### PR DESCRIPTION
While integrating the library into our project, we ran into an issue related to the transport array passed from window.top.
In our setup, the transport object is defined in the top-level window and shared with embedded frames. However, due to JavaScript’s realm isolation, an array created in window.top is not recognized as an instance of Array in the current window context.

As a result, the check transport instanceof Array fails, even though transport is a valid array.

<img width="654" height="249" alt=" window app_ options web socket notifications client connection instanceof Array" src="https://github.com/user-attachments/assets/ebbf88df-68e1-4f2a-90fc-459cf113f5fa" />
