### PR TITLE
Align state invalidation: both disconnect paths, unrecoverable resubscribe, named codes

### DIFF
--- a/src/centrifuge.test.ts
+++ b/src/centrifuge.test.ts
@@ -78,12 +78,12 @@ test('state invalidated disconnect (3014) clears token and map state', () => {
   expect((sub as any)._mapCursor).toBe('');
   expect((sub as any)._prevValueMap.size).toBe(0);
 
-  // Stream subscription: token cleared, position preserved, but stale delta
-  // base dropped — a stale base would corrupt decoding of the first pub
-  // after re-subscribe.
+  // Stream subscription: token cleared, recovery position reset to the
+  // unrecoverable sentinel (epoch "_", offset 0) so the resubscribe reports
+  // was_recovering=true, recovered=false, and stale delta base dropped.
   expect((streamSub as any)._token).toBe('');
-  expect((streamSub as any)._offset).toBe(10);
-  expect((streamSub as any)._epoch).toBe('def');
+  expect((streamSub as any)._offset).toBe(0);
+  expect((streamSub as any)._epoch).toBe('_');
   expect((streamSub as any)._prevValueMap.size).toBe(0);
 
   // Shared poll subscription: delta base also cleared for the same reason.

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -5,7 +5,7 @@ import {
   SharedPollSubscription as _SharedPollSubscription
 } from './subscription';
 import {
-  errorCodes, disconnectedCodes,
+  errorCodes, disconnectedCodes, unsubscribedCodes,
   connectingCodes, subscribingCodes
 } from './codes';
 
@@ -1450,6 +1450,22 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
   }
 
   private _disconnect(code: number, reason: string, reconnect: boolean) {
+    if (code === disconnectedCodes.stateInvalidated) {
+      // State invalidated: clear connection token (forcing a fresh one via
+      // getToken on reconnect) and invalidate all subscription state. Done here
+      // (the shared funnel) so it fires whether it arrives as a Disconnect push
+      // or as a raw WebSocket close code — and before _clearConnectedState below
+      // moves subscriptions to subscribing for the resubscribe. Runs ahead of the
+      // isDisconnected guard so the invalidation is unconditional.
+      this._token = '';
+      this._refreshRequired = true;
+      for (const channel in this._subs) {
+        if (this._subs.hasOwnProperty(channel)) {
+          // @ts-ignore – _invalidateState is internal.
+          this._subs[channel]._invalidateState();
+        }
+      }
+    }
     if (this._isDisconnected()) {
       return;
     }
@@ -1930,9 +1946,9 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
       // @ts-ignore – we are hiding some symbols from public API autocompletion.
       sub._setUnsubscribed(unsubscribe.code, unsubscribe.reason, false);
     } else {
-      if (unsubscribe.code === 2502) {
-        // State invalidated: clear subscription token and map state
-        // so resubscribe gets a fresh token and does full re-sync.
+      if (unsubscribe.code === unsubscribedCodes.stateInvalidated) {
+        // State invalidated: clear subscription token and cached state so the
+        // resubscribe gets a fresh token and re-syncs.
         // @ts-ignore – _invalidateState is internal.
         sub._invalidateState();
       }
@@ -1956,17 +1972,9 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     if ((code >= 3500 && code < 4000) || (code >= 4500 && code < 5000)) {
       reconnect = false;
     }
-    if (code === 3014) {
-      // State invalidated: clear connection token and invalidate all subscription state.
-      this._token = '';
-      this._refreshRequired = true;
-      for (const channel in this._subs) {
-        if (this._subs.hasOwnProperty(channel)) {
-          // @ts-ignore – _invalidateState is internal.
-          this._subs[channel]._invalidateState();
-        }
-      }
-    }
+    // State invalidation (code 3014) is handled centrally in _disconnect so it
+    // covers both delivery paths: a Disconnect push (this method) and a raw
+    // WebSocket close code (transport onClose → _disconnect directly).
     this._disconnect(code, disconnect.reason, reconnect);
   }
 

--- a/src/codes.ts
+++ b/src/codes.ts
@@ -27,7 +27,12 @@ export enum disconnectedCodes {
   disconnectCalled = 0,
   unauthorized = 1,
   badProtocol = 2,
-  messageSizeLimit = 3
+  messageSizeLimit = 3,
+  // Server-sent: the connection's cached state and/or token are no longer valid.
+  // The client clears the connection token (to force getToken), invalidates all
+  // subscription state, and reconnects. Delivered as a Disconnect push or a raw
+  // WebSocket close code.
+  stateInvalidated = 3014
 }
 
 export enum subscribingCodes {
@@ -38,7 +43,11 @@ export enum subscribingCodes {
 export enum unsubscribedCodes {
   unsubscribeCalled = 0,
   unauthorized = 1,
-  clientClosed = 2
+  clientClosed = 2,
+  // Server-sent (in an Unsubscribe push): this subscription's cached state
+  // and/or token are no longer valid. The client clears the subscription state
+  // and resubscribes (this is a temporary unsubscribe, code >= 2500).
+  stateInvalidated = 2502
 }
 
 export enum subscriptionFlags {

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -427,12 +427,23 @@ export class BaseSubscription extends (EventEmitter as new () => TypedEventEmitt
     // unsubscribe via _setUnsubscribed.
   }
 
-  /** Called when server sends "state invalidated" disconnect (code 3014).
-   *  Clears subscription token and resets cached state so next subscribe
-   *  obtains a fresh token and does a full state re-sync. Delta base is
-   *  cleared for every subscription type (stream/map/shared_poll all use
-   *  _prevValueMap for fossil delta) — a stale base would corrupt decoding
-   *  of the first publication after re-subscribe. */
+  /** Called on "state invalidated" — unsubscribe code 2502 for this channel,
+   *  or connection disconnect code 3014. Clears the token (next subscribe
+   *  fetches a fresh one) and the fossil delta base (every subscription type
+   *  uses _prevValueMap; a stale base would corrupt decoding of the first
+   *  publication after re-subscribe).
+   *
+   *  Map subscriptions restart from scratch: their recovery position and
+   *  materialized-state buffers are dropped so the next subscribe does a full
+   *  STATE re-sync.
+   *
+   *  Stream/shared-poll subscriptions instead reset the recovery position to a
+   *  sentinel epoch ("_") the server can never match (offset 0), leaving
+   *  _recover untouched: a recoverable subscription then resubscribes with
+   *  was_recovering=true, recovered=false (so the app reloads via its existing
+   *  recovery-failure path rather than treating it as a brand-new first
+   *  subscribe), while a non-recoverable one simply resubscribes. The real
+   *  epoch/offset are adopted from the subscribe reply. */
   _invalidateState() {
     this._token = '';
     this._prevValueMap = new Map();
@@ -444,6 +455,9 @@ export class BaseSubscription extends (EventEmitter as new () => TypedEventEmitt
       this._mapStreamBuffer = [];
       this._mapCursor = '';
       this._mapPhase = null;
+    } else {
+      this._offset = 0;
+      this._epoch = '_';
     }
   }
 


### PR DESCRIPTION
Refines the existing state-invalidation handling (unsubscribe 2502 / disconnect 3014):

- **Both disconnect paths.** The 3014 connection-token clear + subscription invalidation moved into the shared `_disconnect` funnel, so it fires whether 3014 arrives as a Disconnect **push** or a raw **WebSocket close code**. Previously only the push path (`_handleDisconnect`) ran it, so a 3014 close frame was missed.
- **Unrecoverable resubscribe.** For stream/shared-poll subscriptions, `_invalidateState` now resets the recovery position to a sentinel epoch (`"_"`, offset 0) the server can never match and leaves `_recover` untouched, so a recoverable subscription resubscribes with `was_recovering=true, recovered=false` — letting the app reload via its existing recovery-failure path instead of looking like a brand-new first subscribe. **Map subscriptions still restart from scratch** (full STATE re-sync). The real epoch/offset are adopted from the subscribe reply.
- **Named codes.** Replaced bare `2502`/`3014` literals with `unsubscribedCodes.stateInvalidated` / `disconnectedCodes.stateInvalidated` in `codes.ts`.

Tests updated in `centrifuge.test.ts`.
