### PR TITLE
Dictionary compression support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
-        node-version: [18, 20, 22, 24, 25]
+        node-version: [20, 22, 24, 25]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -35,9 +35,8 @@
     "docs": "typedoc --exclude '**/transport_*.ts' --exclude '**/*.test.ts' --exclude '**/*+(utils|json|protobuf.codec|codes|browser).ts' --excludePrivate --excludeInternal --entryPoints src/*.ts",
     "build-all": "yarn clean && yarn build && yarn build-browser && yarn build-browser-protobuf",
     "build-browser": "esbuild src/browser.ts --bundle --minify --sourcemap --outfile=dist/centrifuge.js",
-    "dev": "esbuild src/browser.ts --bundle --outfile=dist/centrifuge.js --servedir=dist/ --serve=2000",
+    "dev": "esbuild src/browser.protobuf.ts --bundle --outfile=dist/centrifuge.protobuf.js --watch=forever & esbuild src/browser.ts --bundle --outfile=dist/centrifuge.js --servedir=dist/ --serve=2000",
     "build-browser-protobuf": "esbuild src/browser.protobuf.ts --bundle --minify --sourcemap --outfile=dist/centrifuge.protobuf.js",
-    "dev-protobuf": "esbuild src/browser.protobuf.ts --bundle --outfile=dist/centrifuge.protobuf.js --servedir=dist/ --serve=2000",
     "proto": "./make-proto"
   },
   "devDependencies": {
@@ -87,6 +86,7 @@
   "homepage": "https://github.com/centrifugal/centrifuge-js",
   "dependencies": {
     "events": "^3.3.0",
+    "fflate": "^0.8.3",
     "protobufjs": "^7.6.0"
   }
 }

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -16,6 +16,8 @@ import { SseTransport } from './transport_sse';
 import { WebtransportTransport } from './transport_webtransport';
 
 import { JsonCodec } from './json';
+import { FrameCodec, frameCodecFromDictionary, frameByteLength, supportedConnectionFlags, connectionFlagDictionaryCompression } from './frame_codec';
+import { DictionaryCache, sharedDictionaryCache } from './dictionary_cache';
 
 import {
   isFunction, log, startsWith, errorExists,
@@ -29,7 +31,7 @@ import {
   SharedPollSubscriptionOptions, SharedPollSubscriptionEvents, SharedPollTrackItem,
   HistoryOptions, HistoryResult, PublishResult,
   PresenceResult, PresenceStatsResult, SubscribedContext,
-  TransportEndpoint,
+  TransportEndpoint, CompressionStats
 } from './types';
 
 import EventEmitter from 'events';
@@ -131,6 +133,21 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
   private _data: any;
   private _dispatchPromise: Promise<void>;
   private _serverPing: number;
+  /**
+   * Dictionary compression state. Non-null once the server has sent a
+   * dictionary; every frame after that point carries a codec marker.
+   * @internal
+   */
+  private _frameCodec: FrameCodec | null = null;
+  /** @internal */
+  private _compressionAccepted = false;
+  /**
+   * Total bytes delivered by the transport, counted before any decompression.
+   * Tracked in both modes so the two can be compared.
+   * @internal
+   */
+  private _transportBytesIn = 0;
+  private _dictionaries: DictionaryCache = sharedDictionaryCache;
   private _serverPingTimeout?: null | ReturnType<typeof setTimeout> = null;
   private _sendPong: boolean;
   private _promises: Record<number, any>;
@@ -628,6 +645,38 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     log('debug', args);
   }
 
+  /**
+   * compressionStats returns what this connection measured about dictionary
+   * compression.
+   *
+   * Byte counts are exact at the protocol frame level, but read them with two
+   * caveats: they compare against sending the same frames uncompressed rather
+   * than against permessage-deflate, and they are measured on WebSocket message
+   * payloads, so they exclude WebSocket and TCP framing which compression also
+   * shrinks slightly. The figure is therefore a small underestimate.
+   *
+   * Frames received before compression activated are not counted at all, so this
+   * reports steady state rather than the whole connection.
+   */
+  compressionStats(): CompressionStats {
+    const s = this._frameCodec !== null
+      ? this._frameCodec.getStats()
+      : { frames: 0, bytesReceived: 0, bytesDecompressed: 0, dictionaryBytes: 0 };
+    const saved = s.bytesDecompressed - s.bytesReceived - s.dictionaryBytes;
+    return {
+      accepted: this._compressionAccepted,
+      active: this._frameCodec !== null,
+      dictionaryId: this._frameCodec !== null ? this._frameCodec.id : '',
+      frames: s.frames,
+      bytesReceived: s.bytesReceived,
+      bytesDecompressed: s.bytesDecompressed,
+      dictionaryBytes: s.dictionaryBytes,
+      bytesSaved: saved,
+      ratio: s.bytesReceived > 0 ? s.bytesDecompressed / s.bytesReceived : 0,
+      transportBytesReceived: this._transportBytesIn,
+    };
+  }
+
   private _codecName(): string {
     return this._codec.name()
   }
@@ -776,6 +825,12 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
 
   private _clearConnectedState() {
     this._client = null;
+    // Compression is negotiated per connection: a reconnect must start over,
+    // and must not try to decode the next connection's frames with a dictionary
+    // that connection never received.
+    this._frameCodec = null;
+    this._compressionAccepted = false;
+    this._transportBytesIn = 0;
     this._clearServerPingTimeout();
     this._clearRefreshTimeout();
 
@@ -1281,6 +1336,17 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     if (Object.keys(this._config.headers).length > 0) {
       req.headers = this._config.headers;
     }
+    // Always advertise every connection-level capability this SDK can handle.
+    // There is no user-facing option on purpose: the client states capability,
+    // the server decides what to use, and a server supporting none ignores it.
+    req.flag = supportedConnectionFlags;
+    // Dictionaries kept from earlier connections. The server answers with an id
+    // alone for anything it recognises, so a returning client is compressed from
+    // its first frame without paying for the transfer again.
+    const heldIds = this._dictionaries.ids();
+    if (heldIds.length > 0) {
+      req.state = { dictionary_ids: heldIds };
+    }
 
     const subs = {};
     let hasSubs = false;
@@ -1369,7 +1435,54 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     if (this._serverPing > 0) {
       this._waitServerPing();
     }
+    this._transportBytesIn += frameByteLength(data);
+    if (this._frameCodec !== null) {
+      try {
+        data = this._frameCodec.decode(data, this._codec.name() === 'json');
+      } catch (e) {
+        this._debug('frame decode error', e);
+        // A cached dictionary that cannot decode is a stale or corrupted entry:
+        // drop it so the next connection does not advertise it again and wedge
+        // this client in a loop.
+        this._dictionaries.forget(this._frameCodec.id);
+        this._disconnect(disconnectedCodes.badProtocol, 'frame decode error', true);
+        return;
+      }
+    }
     const replies = this._codec.decodeReplies(data);
+    // A dictionary arriving in this frame takes effect from the NEXT frame: the
+    // frame carrying it is itself encoded with whatever was already in use,
+    // since the client can not decode anything until the new one is applied.
+    // Decoding above is already done, so installing here is safe.
+    //
+    // This must happen here rather than in reply dispatch, which is asynchronous
+    // - the next frame can arrive before a dispatched handler runs, and would
+    // then be decoded with the wrong dictionary or none at all.
+    for (const i in replies) {
+      if (!replies.hasOwnProperty(i)) continue;
+      const reply = replies[i];
+      const push = reply.push;
+      if (push && push.state && push.state.dictionary) {
+        const codec = frameCodecFromDictionary(push.state.dictionary, this._dictionaries);
+        if (codec !== null) {
+          // Only the structure dictionary is remembered, and it is always the
+          // first a connection receives. Channel dictionaries carry fragments of
+          // other users' messages and are never written to storage.
+          if (this._frameCodec === null) {
+            this._dictionaries.put(codec.id, codec.dictionary);
+          }
+          this._frameCodec = codec;
+          this._debug('dictionary compression activated, id', codec.id);
+        } else {
+          // The server named a dictionary this client does not hold, so nothing
+          // after this frame can be decoded. Forget it and start over rather
+          // than misread everything that follows.
+          this._dictionaries.forget(push.state.dictionary.id || '');
+          this._disconnect(disconnectedCodes.badProtocol, 'unknown dictionary', true);
+          return;
+        }
+      }
+    }
     // We have to guarantee order of events in replies processing - i.e. start processing
     // next reply only when we finished processing of current one. Without syncing things in
     // this way we could get wrong publication events order as reply promises resolve
@@ -1713,6 +1826,9 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     }
 
     this._client = result.client;
+    // A client can not assume a capability it advertised was accepted: the node
+    // may have it disabled, or may decline this connection.
+    this._compressionAccepted = ((result.flag || 0) & connectionFlagDictionaryCompression) !== 0;
     this._setState(State.Connected);
 
     if (this._refreshTimeout) {

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -1852,6 +1852,13 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     // A client can not assume a capability it advertised was accepted: the node
     // may have it disabled, or may decline this connection.
     this._compressionAccepted = ((result.flag || 0) & connectionFlagDictionaryCompression) !== 0;
+    if (!this._compressionAccepted && this._frameCodec !== null) {
+      // A codec installed from cache before connecting, on a connection the
+      // server then declined to compress. It marks this reply so we could read
+      // it, and nothing after it - so keeping the codec would mean stripping a
+      // marker off frames that do not have one.
+      this._frameCodec = null;
+    }
     this._setState(State.Connected);
 
     if (this._refreshTimeout) {

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -71,6 +71,7 @@ const defaults: Options = {
   debug: false,
   name: 'js',
   version: '',
+  profile: '',
   fetch: null,
   readableStream: null,
   websocket: null,
@@ -1343,9 +1344,12 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     // Dictionaries kept from earlier connections. The server answers with an id
     // alone for anything it recognises, so a returning client is compressed from
     // its first frame without paying for the transfer again.
-    const heldIds = this._dictionaries.ids();
-    if (heldIds.length > 0) {
-      req.state = { dictionary_ids: heldIds };
+    const held = this._dictionaries.advertise();
+    if (held !== '') {
+      req.dict = held;
+    }
+    if (this._config.profile !== '') {
+      req.profile = this._config.profile;
     }
 
     const subs = {};
@@ -1461,14 +1465,20 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     for (const i in replies) {
       if (!replies.hasOwnProperty(i)) continue;
       const reply = replies[i];
-      const push = reply.push;
-      if (push && push.state && push.state.dictionary) {
-        const codec = frameCodecFromDictionary(push.state.dictionary, this._dictionaries);
+      // Compression is set up by the connect reply, which is the frame that
+      // carries the dictionary. A push may replace it later, which the protocol
+      // allows but the server does not currently do.
+      const connectDict = reply.connect && reply.connect.dict;
+      const pushDict = reply.push && reply.push.state && reply.push.state.dict;
+      const dict = connectDict || pushDict;
+      if (dict) {
+        const codec = frameCodecFromDictionary(dict, this._dictionaries);
         if (codec !== null) {
-          // Only the structure dictionary is remembered, and it is always the
-          // first a connection receives. Channel dictionaries carry fragments of
-          // other users' messages and are never written to storage.
-          if (this._frameCodec === null) {
+          // The dictionary from the connect reply belongs to this client's
+          // profile and changes only when the server publishes a new version,
+          // so keeping it turns the next connect into an id and no transfer.
+          // One arriving later in a push is connection-scoped and is not kept.
+          if (connectDict) {
             this._dictionaries.put(codec.id, codec.dictionary);
           }
           this._frameCodec = codec;
@@ -1477,7 +1487,7 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
           // The server named a dictionary this client does not hold, so nothing
           // after this frame can be decoded. Forget it and start over rather
           // than misread everything that follows.
-          this._dictionaries.forget(push.state.dictionary.id || '');
+          this._dictionaries.forget(dict.id || '');
           this._disconnect(disconnectedCodes.badProtocol, 'unknown dictionary', true);
           return;
         }

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -1347,6 +1347,19 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     const held = this._dictionaries.advertise();
     if (held !== '') {
       req.dict = held;
+      // Install the codec for the bytes we are advertising, before the reply
+      // arrives. A server that recognises this id compresses the connect reply
+      // itself - there is nothing left to wait for once both sides hold the
+      // dictionary - so waiting to learn the codec from a reply would mean
+      // never being able to read the reply that teaches it.
+      //
+      // Safe when the server does not recognise it either: a frame carries a
+      // codec marker, so a raw reply still passes through untouched and the
+      // dictionary it delivers replaces this one below.
+      const heldBytes = this._dictionaries.get(held);
+      if (heldBytes !== null) {
+        this._frameCodec = new FrameCodec(held, heldBytes);
+      }
     }
     if (this._config.profile !== '') {
       req.profile = this._config.profile;

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -1470,21 +1470,17 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
       if (!replies.hasOwnProperty(i)) continue;
       const reply = replies[i];
       // Compression is set up by the connect reply, which is the frame that
-      // carries the dictionary. A push may replace it later, which the protocol
-      // allows but the server does not currently do.
-      const connectDict = reply.connect && reply.connect.dict;
-      const pushDict = reply.push && reply.push.state && reply.push.state.dict;
-      const dict = connectDict || pushDict;
+      // carries the dictionary. There is no way to replace it mid-connection:
+      // the frame announcing a new dictionary would have to be encoded against
+      // the old one, so the protocol does not offer it.
+      const dict = reply.connect && reply.connect.dict;
       if (dict) {
         const codec = frameCodecFromDictionary(dict, this._dictionaries);
         if (codec !== null) {
-          // The dictionary from the connect reply belongs to this client's
-          // profile and changes only when the server publishes a new version,
-          // so keeping it turns the next connect into an id and no transfer.
-          // One arriving later in a push is connection-scoped and is not kept.
-          if (connectDict) {
-            this._dictionaries.put(codec.id, codec.dictionary);
-          }
+          // This dictionary belongs to the client's profile and changes only
+          // when the server publishes a new version, so keeping it turns the
+          // next connect into an id and no transfer.
+          this._dictionaries.put(codec.id, codec.dictionary);
           this._frameCodec = codec;
           this._debug('dictionary compression activated, id', codec.id);
         } else {

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -148,7 +148,7 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
    * @internal
    */
   private _transportBytesIn = 0;
-  private _dictionaries: DictionaryCache = sharedDictionaryCache;
+  private _dictionary: DictionaryCache = sharedDictionaryCache;
   private _serverPingTimeout?: null | ReturnType<typeof setTimeout> = null;
   private _sendPong: boolean;
   private _promises: Record<number, any>;
@@ -1344,7 +1344,7 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     // Dictionaries kept from earlier connections. The server answers with an id
     // alone for anything it recognises, so a returning client is compressed from
     // its first frame without paying for the transfer again.
-    const held = this._dictionaries.advertise();
+    const held = this._dictionary.advertise();
     if (held !== '') {
       // Advertised, but no codec is installed yet. The connect reply is always
       // an ordinary protocol frame, so there is nothing to decode until the
@@ -1452,7 +1452,7 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
         // A cached dictionary that cannot decode is a stale or corrupted entry:
         // drop it so the next connection does not advertise it again and wedge
         // this client in a loop.
-        this._dictionaries.forget(this._frameCodec.id);
+        this._dictionary.forget(this._frameCodec.id);
         this._disconnect(disconnectedCodes.badProtocol, 'frame decode error', true);
         return;
       }
@@ -1475,19 +1475,19 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
       // the old one, so the protocol does not offer it.
       const dict = reply.connect && reply.connect.dict;
       if (dict) {
-        const codec = frameCodecFromDictionary(dict, this._dictionaries);
+        const codec = frameCodecFromDictionary(dict, this._dictionary);
         if (codec !== null) {
           // This dictionary belongs to the client's profile and changes only
           // when the server publishes a new version, so keeping it turns the
           // next connect into an id and no transfer.
-          this._dictionaries.put(codec.id, codec.dictionary);
+          this._dictionary.put(codec.id, codec.dictionary);
           this._frameCodec = codec;
           this._debug('dictionary compression activated, id', codec.id);
         } else {
           // The server named a dictionary this client does not hold, so nothing
           // after this frame can be decoded. Forget it and start over rather
           // than misread everything that follows.
-          this._dictionaries.forget(dict.id || '');
+          this._dictionary.forget(dict.id || '');
           this._disconnect(disconnectedCodes.badProtocol, 'unknown dictionary', true);
           return;
         }

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -1346,20 +1346,11 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     // its first frame without paying for the transfer again.
     const held = this._dictionaries.advertise();
     if (held !== '') {
+      // Advertised, but no codec is installed yet. The connect reply is always
+      // an ordinary protocol frame, so there is nothing to decode until the
+      // reply has told us which dictionary applies - at which point it is
+      // installed for the frames that follow.
       req.dict = held;
-      // Install the codec for the bytes we are advertising, before the reply
-      // arrives. A server that recognises this id compresses the connect reply
-      // itself - there is nothing left to wait for once both sides hold the
-      // dictionary - so waiting to learn the codec from a reply would mean
-      // never being able to read the reply that teaches it.
-      //
-      // Safe when the server does not recognise it either: a frame carries a
-      // codec marker, so a raw reply still passes through untouched and the
-      // dictionary it delivers replaces this one below.
-      const heldBytes = this._dictionaries.get(held);
-      if (heldBytes !== null) {
-        this._frameCodec = new FrameCodec(held, heldBytes);
-      }
     }
     if (this._config.profile !== '') {
       req.profile = this._config.profile;
@@ -1852,13 +1843,6 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     // A client can not assume a capability it advertised was accepted: the node
     // may have it disabled, or may decline this connection.
     this._compressionAccepted = ((result.flag || 0) & connectionFlagDictionaryCompression) !== 0;
-    if (!this._compressionAccepted && this._frameCodec !== null) {
-      // A codec installed from cache before connecting, on a connection the
-      // server then declined to compress. It marks this reply so we could read
-      // it, and nothing after it - so keeping the codec would mean stripping a
-      // marker off frames that do not have one.
-      this._frameCodec = null;
-    }
     this._setState(State.Connected);
 
     if (this._refreshTimeout) {

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -31,7 +31,7 @@ import {
   SharedPollSubscriptionOptions, SharedPollSubscriptionEvents, SharedPollTrackItem,
   HistoryOptions, HistoryResult, PublishResult,
   PresenceResult, PresenceStatsResult, SubscribedContext,
-  TransportEndpoint, CompressionStats
+  TransportEndpoint, DictionaryCompressionStats
 } from './types';
 
 import EventEmitter from 'events';
@@ -647,8 +647,8 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
   }
 
   /**
-   * compressionStats returns what this connection measured about dictionary
-   * compression.
+   * dictionaryCompressionStats returns what this connection measured on the
+   * frames it decoded against a dictionary.
    *
    * Byte counts are exact at the protocol frame level, but read them with two
    * caveats: they compare against sending the same frames uncompressed rather
@@ -659,7 +659,7 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
    * Frames received before compression activated are not counted at all, so this
    * reports steady state rather than the whole connection.
    */
-  compressionStats(): CompressionStats {
+  dictionaryCompressionStats(): DictionaryCompressionStats {
     const s = this._frameCodec !== null
       ? this._frameCodec.getStats()
       : { frames: 0, bytesReceived: 0, bytesDecompressed: 0, dictionaryBytes: 0 };

--- a/src/client_proto.d.ts
+++ b/src/client_proto.d.ts
@@ -494,9 +494,6 @@ export namespace centrifugal {
 
                 /** Push refresh */
                 refresh?: (centrifugal.centrifuge.protocol.IRefresh|null);
-
-                /** Push state */
-                state?: (centrifugal.centrifuge.protocol.IConnectionState|null);
             }
 
             /** Represents a Push. */
@@ -540,9 +537,6 @@ export namespace centrifugal {
 
                 /** Push refresh. */
                 public refresh?: (centrifugal.centrifuge.protocol.IRefresh|null);
-
-                /** Push state. */
-                public state?: (centrifugal.centrifuge.protocol.IConnectionState|null);
 
                 /**
                  * Encodes the specified Push message. Does not implicitly {@link centrifugal.centrifuge.protocol.Push.verify|verify} messages.
@@ -588,75 +582,6 @@ export namespace centrifugal {
 
                 /**
                  * Gets the default type url for Push
-                 * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-                 * @returns The default type url
-                 */
-                public static getTypeUrl(typeUrlPrefix?: string): string;
-            }
-
-            /** Properties of a ConnectionState. */
-            interface IConnectionState {
-
-                /** ConnectionState dict */
-                dict?: (centrifugal.centrifuge.protocol.IDictionary|null);
-            }
-
-            /** Represents a ConnectionState. */
-            class ConnectionState implements IConnectionState {
-
-                /**
-                 * Constructs a new ConnectionState.
-                 * @param [properties] Properties to set
-                 */
-                constructor(properties?: centrifugal.centrifuge.protocol.IConnectionState);
-
-                /** ConnectionState dict. */
-                public dict?: (centrifugal.centrifuge.protocol.IDictionary|null);
-
-                /**
-                 * Encodes the specified ConnectionState message. Does not implicitly {@link centrifugal.centrifuge.protocol.ConnectionState.verify|verify} messages.
-                 * @param message ConnectionState message or plain object to encode
-                 * @param [writer] Writer to encode to
-                 * @returns Writer
-                 */
-                public static encode(message: centrifugal.centrifuge.protocol.IConnectionState, writer?: $protobuf.Writer): $protobuf.Writer;
-
-                /**
-                 * Encodes the specified ConnectionState message, length delimited. Does not implicitly {@link centrifugal.centrifuge.protocol.ConnectionState.verify|verify} messages.
-                 * @param message ConnectionState message or plain object to encode
-                 * @param [writer] Writer to encode to
-                 * @returns Writer
-                 */
-                public static encodeDelimited(message: centrifugal.centrifuge.protocol.IConnectionState, writer?: $protobuf.Writer): $protobuf.Writer;
-
-                /**
-                 * Decodes a ConnectionState message from the specified reader or buffer.
-                 * @param reader Reader or buffer to decode from
-                 * @param [length] Message length if known beforehand
-                 * @returns ConnectionState
-                 * @throws {Error} If the payload is not a reader or valid buffer
-                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
-                 */
-                public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): centrifugal.centrifuge.protocol.ConnectionState;
-
-                /**
-                 * Decodes a ConnectionState message from the specified reader or buffer, length delimited.
-                 * @param reader Reader or buffer to decode from
-                 * @returns ConnectionState
-                 * @throws {Error} If the payload is not a reader or valid buffer
-                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
-                 */
-                public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): centrifugal.centrifuge.protocol.ConnectionState;
-
-                /**
-                 * Verifies a ConnectionState message.
-                 * @param message Plain object to verify
-                 * @returns `null` if valid, otherwise the reason why it is not
-                 */
-                public static verify(message: { [k: string]: any }): (string|null);
-
-                /**
-                 * Gets the default type url for ConnectionState
                  * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
                  * @returns The default type url
                  */

--- a/src/client_proto.d.ts
+++ b/src/client_proto.d.ts
@@ -597,8 +597,8 @@ export namespace centrifugal {
             /** Properties of a ConnectionState. */
             interface IConnectionState {
 
-                /** ConnectionState dictionary */
-                dictionary?: (centrifugal.centrifuge.protocol.IDictionary|null);
+                /** ConnectionState dict */
+                dict?: (centrifugal.centrifuge.protocol.IDictionary|null);
             }
 
             /** Represents a ConnectionState. */
@@ -610,8 +610,8 @@ export namespace centrifugal {
                  */
                 constructor(properties?: centrifugal.centrifuge.protocol.IConnectionState);
 
-                /** ConnectionState dictionary. */
-                public dictionary?: (centrifugal.centrifuge.protocol.IDictionary|null);
+                /** ConnectionState dict. */
+                public dict?: (centrifugal.centrifuge.protocol.IDictionary|null);
 
                 /**
                  * Encodes the specified ConnectionState message. Does not implicitly {@link centrifugal.centrifuge.protocol.ConnectionState.verify|verify} messages.
@@ -1655,6 +1655,12 @@ export namespace centrifugal {
 
                 /** ConnectRequest flag */
                 flag?: (number|Long|null);
+
+                /** ConnectRequest profile */
+                profile?: (string|null);
+
+                /** ConnectRequest dict */
+                dict?: (string|null);
             }
 
             /** Represents a ConnectRequest. */
@@ -1686,6 +1692,12 @@ export namespace centrifugal {
 
                 /** ConnectRequest flag. */
                 public flag: (number|Long);
+
+                /** ConnectRequest profile. */
+                public profile: string;
+
+                /** ConnectRequest dict. */
+                public dict: string;
 
                 /**
                  * Encodes the specified ConnectRequest message. Does not implicitly {@link centrifugal.centrifuge.protocol.ConnectRequest.verify|verify} messages.
@@ -1775,6 +1787,9 @@ export namespace centrifugal {
 
                 /** ConnectResult flag */
                 flag?: (number|Long|null);
+
+                /** ConnectResult dict */
+                dict?: (centrifugal.centrifuge.protocol.IDictionary|null);
             }
 
             /** Represents a ConnectResult. */
@@ -1821,6 +1836,9 @@ export namespace centrifugal {
 
                 /** ConnectResult flag. */
                 public flag: (number|Long);
+
+                /** ConnectResult dict. */
+                public dict?: (centrifugal.centrifuge.protocol.IDictionary|null);
 
                 /**
                  * Encodes the specified ConnectResult message. Does not implicitly {@link centrifugal.centrifuge.protocol.ConnectResult.verify|verify} messages.

--- a/src/client_proto.d.ts
+++ b/src/client_proto.d.ts
@@ -494,6 +494,9 @@ export namespace centrifugal {
 
                 /** Push refresh */
                 refresh?: (centrifugal.centrifuge.protocol.IRefresh|null);
+
+                /** Push state */
+                state?: (centrifugal.centrifuge.protocol.IConnectionState|null);
             }
 
             /** Represents a Push. */
@@ -537,6 +540,9 @@ export namespace centrifugal {
 
                 /** Push refresh. */
                 public refresh?: (centrifugal.centrifuge.protocol.IRefresh|null);
+
+                /** Push state. */
+                public state?: (centrifugal.centrifuge.protocol.IConnectionState|null);
 
                 /**
                  * Encodes the specified Push message. Does not implicitly {@link centrifugal.centrifuge.protocol.Push.verify|verify} messages.
@@ -582,6 +588,156 @@ export namespace centrifugal {
 
                 /**
                  * Gets the default type url for Push
+                 * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+                 * @returns The default type url
+                 */
+                public static getTypeUrl(typeUrlPrefix?: string): string;
+            }
+
+            /** Properties of a ConnectionState. */
+            interface IConnectionState {
+
+                /** ConnectionState dictionary */
+                dictionary?: (centrifugal.centrifuge.protocol.IDictionary|null);
+            }
+
+            /** Represents a ConnectionState. */
+            class ConnectionState implements IConnectionState {
+
+                /**
+                 * Constructs a new ConnectionState.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: centrifugal.centrifuge.protocol.IConnectionState);
+
+                /** ConnectionState dictionary. */
+                public dictionary?: (centrifugal.centrifuge.protocol.IDictionary|null);
+
+                /**
+                 * Encodes the specified ConnectionState message. Does not implicitly {@link centrifugal.centrifuge.protocol.ConnectionState.verify|verify} messages.
+                 * @param message ConnectionState message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encode(message: centrifugal.centrifuge.protocol.IConnectionState, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Encodes the specified ConnectionState message, length delimited. Does not implicitly {@link centrifugal.centrifuge.protocol.ConnectionState.verify|verify} messages.
+                 * @param message ConnectionState message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encodeDelimited(message: centrifugal.centrifuge.protocol.IConnectionState, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Decodes a ConnectionState message from the specified reader or buffer.
+                 * @param reader Reader or buffer to decode from
+                 * @param [length] Message length if known beforehand
+                 * @returns ConnectionState
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): centrifugal.centrifuge.protocol.ConnectionState;
+
+                /**
+                 * Decodes a ConnectionState message from the specified reader or buffer, length delimited.
+                 * @param reader Reader or buffer to decode from
+                 * @returns ConnectionState
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): centrifugal.centrifuge.protocol.ConnectionState;
+
+                /**
+                 * Verifies a ConnectionState message.
+                 * @param message Plain object to verify
+                 * @returns `null` if valid, otherwise the reason why it is not
+                 */
+                public static verify(message: { [k: string]: any }): (string|null);
+
+                /**
+                 * Gets the default type url for ConnectionState
+                 * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+                 * @returns The default type url
+                 */
+                public static getTypeUrl(typeUrlPrefix?: string): string;
+            }
+
+            /** Properties of a Dictionary. */
+            interface IDictionary {
+
+                /** Dictionary id */
+                id?: (string|null);
+
+                /** Dictionary data */
+                data?: (Uint8Array|null);
+
+                /** Dictionary data_b64 */
+                data_b64?: (string|null);
+            }
+
+            /** Represents a Dictionary. */
+            class Dictionary implements IDictionary {
+
+                /**
+                 * Constructs a new Dictionary.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: centrifugal.centrifuge.protocol.IDictionary);
+
+                /** Dictionary id. */
+                public id: string;
+
+                /** Dictionary data. */
+                public data: Uint8Array;
+
+                /** Dictionary data_b64. */
+                public data_b64: string;
+
+                /**
+                 * Encodes the specified Dictionary message. Does not implicitly {@link centrifugal.centrifuge.protocol.Dictionary.verify|verify} messages.
+                 * @param message Dictionary message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encode(message: centrifugal.centrifuge.protocol.IDictionary, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Encodes the specified Dictionary message, length delimited. Does not implicitly {@link centrifugal.centrifuge.protocol.Dictionary.verify|verify} messages.
+                 * @param message Dictionary message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encodeDelimited(message: centrifugal.centrifuge.protocol.IDictionary, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Decodes a Dictionary message from the specified reader or buffer.
+                 * @param reader Reader or buffer to decode from
+                 * @param [length] Message length if known beforehand
+                 * @returns Dictionary
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): centrifugal.centrifuge.protocol.Dictionary;
+
+                /**
+                 * Decodes a Dictionary message from the specified reader or buffer, length delimited.
+                 * @param reader Reader or buffer to decode from
+                 * @returns Dictionary
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): centrifugal.centrifuge.protocol.Dictionary;
+
+                /**
+                 * Verifies a Dictionary message.
+                 * @param message Plain object to verify
+                 * @returns `null` if valid, otherwise the reason why it is not
+                 */
+                public static verify(message: { [k: string]: any }): (string|null);
+
+                /**
+                 * Gets the default type url for Dictionary
                  * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
                  * @returns The default type url
                  */
@@ -1616,6 +1772,9 @@ export namespace centrifugal {
 
                 /** ConnectResult time */
                 time?: (number|Long|null);
+
+                /** ConnectResult flag */
+                flag?: (number|Long|null);
             }
 
             /** Represents a ConnectResult. */
@@ -1659,6 +1818,9 @@ export namespace centrifugal {
 
                 /** ConnectResult time. */
                 public time: (number|Long);
+
+                /** ConnectResult flag. */
+                public flag: (number|Long);
 
                 /**
                  * Encodes the specified ConnectResult message. Does not implicitly {@link centrifugal.centrifuge.protocol.ConnectResult.verify|verify} messages.

--- a/src/client_proto.js
+++ b/src/client_proto.js
@@ -1235,7 +1235,6 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @property {centrifugal.centrifuge.protocol.IConnect|null} [connect] Push connect
                  * @property {centrifugal.centrifuge.protocol.IDisconnect|null} [disconnect] Push disconnect
                  * @property {centrifugal.centrifuge.protocol.IRefresh|null} [refresh] Push refresh
-                 * @property {centrifugal.centrifuge.protocol.IConnectionState|null} [state] Push state
                  */
 
                 /**
@@ -1342,14 +1341,6 @@ export const centrifugal = $root.centrifugal = (() => {
                 Push.prototype.refresh = null;
 
                 /**
-                 * Push state.
-                 * @member {centrifugal.centrifuge.protocol.IConnectionState|null|undefined} state
-                 * @memberof centrifugal.centrifuge.protocol.Push
-                 * @instance
-                 */
-                Push.prototype.state = null;
-
-                /**
                  * Encodes the specified Push message. Does not implicitly {@link centrifugal.centrifuge.protocol.Push.verify|verify} messages.
                  * @function encode
                  * @memberof centrifugal.centrifuge.protocol.Push
@@ -1383,8 +1374,6 @@ export const centrifugal = $root.centrifugal = (() => {
                         $root.centrifugal.centrifuge.protocol.Disconnect.encode(message.disconnect, writer.uint32(/* id 11, wireType 2 =*/90).fork()).ldelim();
                     if (message.refresh != null && Object.hasOwnProperty.call(message, "refresh"))
                         $root.centrifugal.centrifuge.protocol.Refresh.encode(message.refresh, writer.uint32(/* id 12, wireType 2 =*/98).fork()).ldelim();
-                    if (message.state != null && Object.hasOwnProperty.call(message, "state"))
-                        $root.centrifugal.centrifuge.protocol.ConnectionState.encode(message.state, writer.uint32(/* id 13, wireType 2 =*/106).fork()).ldelim();
                     return writer;
                 };
 
@@ -1467,10 +1456,6 @@ export const centrifugal = $root.centrifugal = (() => {
                             }
                         case 12: {
                                 message.refresh = $root.centrifugal.centrifuge.protocol.Refresh.decode(reader, reader.uint32(), undefined, long + 1);
-                                break;
-                            }
-                        case 13: {
-                                message.state = $root.centrifugal.centrifuge.protocol.ConnectionState.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         default:
@@ -1563,11 +1548,6 @@ export const centrifugal = $root.centrifugal = (() => {
                         if (error)
                             return "refresh." + error;
                     }
-                    if (message.state != null && message.hasOwnProperty("state")) {
-                        let error = $root.centrifugal.centrifuge.protocol.ConnectionState.verify(message.state, long + 1);
-                        if (error)
-                            return "state." + error;
-                    }
                     return null;
                 };
 
@@ -1587,161 +1567,6 @@ export const centrifugal = $root.centrifugal = (() => {
                 };
 
                 return Push;
-            })();
-
-            protocol.ConnectionState = (function() {
-
-                /**
-                 * Properties of a ConnectionState.
-                 * @memberof centrifugal.centrifuge.protocol
-                 * @interface IConnectionState
-                 * @property {centrifugal.centrifuge.protocol.IDictionary|null} [dict] ConnectionState dict
-                 */
-
-                /**
-                 * Constructs a new ConnectionState.
-                 * @memberof centrifugal.centrifuge.protocol
-                 * @classdesc Represents a ConnectionState.
-                 * @implements IConnectionState
-                 * @constructor
-                 * @param {centrifugal.centrifuge.protocol.IConnectionState=} [properties] Properties to set
-                 */
-                function ConnectionState(properties) {
-                    if (properties)
-                        for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
-                                this[keys[i]] = properties[keys[i]];
-                }
-
-                /**
-                 * ConnectionState dict.
-                 * @member {centrifugal.centrifuge.protocol.IDictionary|null|undefined} dict
-                 * @memberof centrifugal.centrifuge.protocol.ConnectionState
-                 * @instance
-                 */
-                ConnectionState.prototype.dict = null;
-
-                /**
-                 * Encodes the specified ConnectionState message. Does not implicitly {@link centrifugal.centrifuge.protocol.ConnectionState.verify|verify} messages.
-                 * @function encode
-                 * @memberof centrifugal.centrifuge.protocol.ConnectionState
-                 * @static
-                 * @param {centrifugal.centrifuge.protocol.IConnectionState} message ConnectionState message or plain object to encode
-                 * @param {$protobuf.Writer} [writer] Writer to encode to
-                 * @returns {$protobuf.Writer} Writer
-                 */
-                ConnectionState.encode = function encode(message, writer) {
-                    if (!writer)
-                        writer = $Writer.create();
-                    if (message.dict != null && Object.hasOwnProperty.call(message, "dict"))
-                        $root.centrifugal.centrifuge.protocol.Dictionary.encode(message.dict, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                    return writer;
-                };
-
-                /**
-                 * Encodes the specified ConnectionState message, length delimited. Does not implicitly {@link centrifugal.centrifuge.protocol.ConnectionState.verify|verify} messages.
-                 * @function encodeDelimited
-                 * @memberof centrifugal.centrifuge.protocol.ConnectionState
-                 * @static
-                 * @param {centrifugal.centrifuge.protocol.IConnectionState} message ConnectionState message or plain object to encode
-                 * @param {$protobuf.Writer} [writer] Writer to encode to
-                 * @returns {$protobuf.Writer} Writer
-                 */
-                ConnectionState.encodeDelimited = function encodeDelimited(message, writer) {
-                    return this.encode(message, writer).ldelim();
-                };
-
-                /**
-                 * Decodes a ConnectionState message from the specified reader or buffer.
-                 * @function decode
-                 * @memberof centrifugal.centrifuge.protocol.ConnectionState
-                 * @static
-                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-                 * @param {number} [length] Message length if known beforehand
-                 * @returns {centrifugal.centrifuge.protocol.ConnectionState} ConnectionState
-                 * @throws {Error} If the payload is not a reader or valid buffer
-                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
-                 */
-                ConnectionState.decode = function decode(reader, length, error, long) {
-                    if (!(reader instanceof $Reader))
-                        reader = $Reader.create(reader);
-                    if (long === undefined)
-                        long = 0;
-                    if (long > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
-                    let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.ConnectionState();
-                    while (reader.pos < end) {
-                        let tag = reader.uint32();
-                        if (tag === error)
-                            break;
-                        switch (tag >>> 3) {
-                        case 1: {
-                                message.dict = $root.centrifugal.centrifuge.protocol.Dictionary.decode(reader, reader.uint32(), undefined, long + 1);
-                                break;
-                            }
-                        default:
-                            reader.skipType(tag & 7, long);
-                            break;
-                        }
-                    }
-                    return message;
-                };
-
-                /**
-                 * Decodes a ConnectionState message from the specified reader or buffer, length delimited.
-                 * @function decodeDelimited
-                 * @memberof centrifugal.centrifuge.protocol.ConnectionState
-                 * @static
-                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-                 * @returns {centrifugal.centrifuge.protocol.ConnectionState} ConnectionState
-                 * @throws {Error} If the payload is not a reader or valid buffer
-                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
-                 */
-                ConnectionState.decodeDelimited = function decodeDelimited(reader) {
-                    if (!(reader instanceof $Reader))
-                        reader = new $Reader(reader);
-                    return this.decode(reader, reader.uint32());
-                };
-
-                /**
-                 * Verifies a ConnectionState message.
-                 * @function verify
-                 * @memberof centrifugal.centrifuge.protocol.ConnectionState
-                 * @static
-                 * @param {Object.<string,*>} message Plain object to verify
-                 * @returns {string|null} `null` if valid, otherwise the reason why it is not
-                 */
-                ConnectionState.verify = function verify(message, long) {
-                    if (typeof message !== "object" || message === null)
-                        return "object expected";
-                    if (long === undefined)
-                        long = 0;
-                    if (long > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
-                    if (message.dict != null && message.hasOwnProperty("dict")) {
-                        let error = $root.centrifugal.centrifuge.protocol.Dictionary.verify(message.dict, long + 1);
-                        if (error)
-                            return "dict." + error;
-                    }
-                    return null;
-                };
-
-                /**
-                 * Gets the default type url for ConnectionState
-                 * @function getTypeUrl
-                 * @memberof centrifugal.centrifuge.protocol.ConnectionState
-                 * @static
-                 * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
-                 * @returns {string} The default type url
-                 */
-                ConnectionState.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
-                    if (typeUrlPrefix === undefined) {
-                        typeUrlPrefix = "type.googleapis.com";
-                    }
-                    return typeUrlPrefix + "/centrifugal.centrifuge.protocol.ConnectionState";
-                };
-
-                return ConnectionState;
             })();
 
             protocol.Dictionary = (function() {

--- a/src/client_proto.js
+++ b/src/client_proto.js
@@ -56,7 +56,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function Error(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -129,12 +129,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                Error.decode = function decode(reader, length) {
+                Error.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.Error();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.code = reader.uint32();
@@ -149,7 +155,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -180,9 +186,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                Error.verify = function verify(message) {
+                Error.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.code != null && message.hasOwnProperty("code"))
                         if (!$util.isInteger(message.code))
                             return "code: integer expected";
@@ -235,7 +245,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function EmulationRequest(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -308,12 +318,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                EmulationRequest.decode = function decode(reader, length) {
+                EmulationRequest.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.EmulationRequest();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.node = reader.string();
@@ -328,7 +344,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -359,9 +375,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                EmulationRequest.verify = function verify(message) {
+                EmulationRequest.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.node != null && message.hasOwnProperty("node"))
                         if (!$util.isString(message.node))
                             return "node: string expected";
@@ -424,7 +444,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function Command(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -597,67 +617,73 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                Command.decode = function decode(reader, length) {
+                Command.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.Command();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.id = reader.uint32();
                                 break;
                             }
                         case 4: {
-                                message.connect = $root.centrifugal.centrifuge.protocol.ConnectRequest.decode(reader, reader.uint32());
+                                message.connect = $root.centrifugal.centrifuge.protocol.ConnectRequest.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 5: {
-                                message.subscribe = $root.centrifugal.centrifuge.protocol.SubscribeRequest.decode(reader, reader.uint32());
+                                message.subscribe = $root.centrifugal.centrifuge.protocol.SubscribeRequest.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 6: {
-                                message.unsubscribe = $root.centrifugal.centrifuge.protocol.UnsubscribeRequest.decode(reader, reader.uint32());
+                                message.unsubscribe = $root.centrifugal.centrifuge.protocol.UnsubscribeRequest.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 7: {
-                                message.publish = $root.centrifugal.centrifuge.protocol.PublishRequest.decode(reader, reader.uint32());
+                                message.publish = $root.centrifugal.centrifuge.protocol.PublishRequest.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 8: {
-                                message.presence = $root.centrifugal.centrifuge.protocol.PresenceRequest.decode(reader, reader.uint32());
+                                message.presence = $root.centrifugal.centrifuge.protocol.PresenceRequest.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 9: {
-                                message.presence_stats = $root.centrifugal.centrifuge.protocol.PresenceStatsRequest.decode(reader, reader.uint32());
+                                message.presence_stats = $root.centrifugal.centrifuge.protocol.PresenceStatsRequest.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 10: {
-                                message.history = $root.centrifugal.centrifuge.protocol.HistoryRequest.decode(reader, reader.uint32());
+                                message.history = $root.centrifugal.centrifuge.protocol.HistoryRequest.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 11: {
-                                message.ping = $root.centrifugal.centrifuge.protocol.PingRequest.decode(reader, reader.uint32());
+                                message.ping = $root.centrifugal.centrifuge.protocol.PingRequest.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 12: {
-                                message.send = $root.centrifugal.centrifuge.protocol.SendRequest.decode(reader, reader.uint32());
+                                message.send = $root.centrifugal.centrifuge.protocol.SendRequest.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 13: {
-                                message.rpc = $root.centrifugal.centrifuge.protocol.RPCRequest.decode(reader, reader.uint32());
+                                message.rpc = $root.centrifugal.centrifuge.protocol.RPCRequest.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 14: {
-                                message.refresh = $root.centrifugal.centrifuge.protocol.RefreshRequest.decode(reader, reader.uint32());
+                                message.refresh = $root.centrifugal.centrifuge.protocol.RefreshRequest.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 15: {
-                                message.sub_refresh = $root.centrifugal.centrifuge.protocol.SubRefreshRequest.decode(reader, reader.uint32());
+                                message.sub_refresh = $root.centrifugal.centrifuge.protocol.SubRefreshRequest.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -688,69 +714,73 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                Command.verify = function verify(message) {
+                Command.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.id != null && message.hasOwnProperty("id"))
                         if (!$util.isInteger(message.id))
                             return "id: integer expected";
                     if (message.connect != null && message.hasOwnProperty("connect")) {
-                        let error = $root.centrifugal.centrifuge.protocol.ConnectRequest.verify(message.connect);
+                        let error = $root.centrifugal.centrifuge.protocol.ConnectRequest.verify(message.connect, long + 1);
                         if (error)
                             return "connect." + error;
                     }
                     if (message.subscribe != null && message.hasOwnProperty("subscribe")) {
-                        let error = $root.centrifugal.centrifuge.protocol.SubscribeRequest.verify(message.subscribe);
+                        let error = $root.centrifugal.centrifuge.protocol.SubscribeRequest.verify(message.subscribe, long + 1);
                         if (error)
                             return "subscribe." + error;
                     }
                     if (message.unsubscribe != null && message.hasOwnProperty("unsubscribe")) {
-                        let error = $root.centrifugal.centrifuge.protocol.UnsubscribeRequest.verify(message.unsubscribe);
+                        let error = $root.centrifugal.centrifuge.protocol.UnsubscribeRequest.verify(message.unsubscribe, long + 1);
                         if (error)
                             return "unsubscribe." + error;
                     }
                     if (message.publish != null && message.hasOwnProperty("publish")) {
-                        let error = $root.centrifugal.centrifuge.protocol.PublishRequest.verify(message.publish);
+                        let error = $root.centrifugal.centrifuge.protocol.PublishRequest.verify(message.publish, long + 1);
                         if (error)
                             return "publish." + error;
                     }
                     if (message.presence != null && message.hasOwnProperty("presence")) {
-                        let error = $root.centrifugal.centrifuge.protocol.PresenceRequest.verify(message.presence);
+                        let error = $root.centrifugal.centrifuge.protocol.PresenceRequest.verify(message.presence, long + 1);
                         if (error)
                             return "presence." + error;
                     }
                     if (message.presence_stats != null && message.hasOwnProperty("presence_stats")) {
-                        let error = $root.centrifugal.centrifuge.protocol.PresenceStatsRequest.verify(message.presence_stats);
+                        let error = $root.centrifugal.centrifuge.protocol.PresenceStatsRequest.verify(message.presence_stats, long + 1);
                         if (error)
                             return "presence_stats." + error;
                     }
                     if (message.history != null && message.hasOwnProperty("history")) {
-                        let error = $root.centrifugal.centrifuge.protocol.HistoryRequest.verify(message.history);
+                        let error = $root.centrifugal.centrifuge.protocol.HistoryRequest.verify(message.history, long + 1);
                         if (error)
                             return "history." + error;
                     }
                     if (message.ping != null && message.hasOwnProperty("ping")) {
-                        let error = $root.centrifugal.centrifuge.protocol.PingRequest.verify(message.ping);
+                        let error = $root.centrifugal.centrifuge.protocol.PingRequest.verify(message.ping, long + 1);
                         if (error)
                             return "ping." + error;
                     }
                     if (message.send != null && message.hasOwnProperty("send")) {
-                        let error = $root.centrifugal.centrifuge.protocol.SendRequest.verify(message.send);
+                        let error = $root.centrifugal.centrifuge.protocol.SendRequest.verify(message.send, long + 1);
                         if (error)
                             return "send." + error;
                     }
                     if (message.rpc != null && message.hasOwnProperty("rpc")) {
-                        let error = $root.centrifugal.centrifuge.protocol.RPCRequest.verify(message.rpc);
+                        let error = $root.centrifugal.centrifuge.protocol.RPCRequest.verify(message.rpc, long + 1);
                         if (error)
                             return "rpc." + error;
                     }
                     if (message.refresh != null && message.hasOwnProperty("refresh")) {
-                        let error = $root.centrifugal.centrifuge.protocol.RefreshRequest.verify(message.refresh);
+                        let error = $root.centrifugal.centrifuge.protocol.RefreshRequest.verify(message.refresh, long + 1);
                         if (error)
                             return "refresh." + error;
                     }
                     if (message.sub_refresh != null && message.hasOwnProperty("sub_refresh")) {
-                        let error = $root.centrifugal.centrifuge.protocol.SubRefreshRequest.verify(message.sub_refresh);
+                        let error = $root.centrifugal.centrifuge.protocol.SubRefreshRequest.verify(message.sub_refresh, long + 1);
                         if (error)
                             return "sub_refresh." + error;
                     }
@@ -808,7 +838,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function Reply(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -991,71 +1021,77 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                Reply.decode = function decode(reader, length) {
+                Reply.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.Reply();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.id = reader.uint32();
                                 break;
                             }
                         case 2: {
-                                message.error = $root.centrifugal.centrifuge.protocol.Error.decode(reader, reader.uint32());
+                                message.error = $root.centrifugal.centrifuge.protocol.Error.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 4: {
-                                message.push = $root.centrifugal.centrifuge.protocol.Push.decode(reader, reader.uint32());
+                                message.push = $root.centrifugal.centrifuge.protocol.Push.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 5: {
-                                message.connect = $root.centrifugal.centrifuge.protocol.ConnectResult.decode(reader, reader.uint32());
+                                message.connect = $root.centrifugal.centrifuge.protocol.ConnectResult.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 6: {
-                                message.subscribe = $root.centrifugal.centrifuge.protocol.SubscribeResult.decode(reader, reader.uint32());
+                                message.subscribe = $root.centrifugal.centrifuge.protocol.SubscribeResult.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 7: {
-                                message.unsubscribe = $root.centrifugal.centrifuge.protocol.UnsubscribeResult.decode(reader, reader.uint32());
+                                message.unsubscribe = $root.centrifugal.centrifuge.protocol.UnsubscribeResult.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 8: {
-                                message.publish = $root.centrifugal.centrifuge.protocol.PublishResult.decode(reader, reader.uint32());
+                                message.publish = $root.centrifugal.centrifuge.protocol.PublishResult.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 9: {
-                                message.presence = $root.centrifugal.centrifuge.protocol.PresenceResult.decode(reader, reader.uint32());
+                                message.presence = $root.centrifugal.centrifuge.protocol.PresenceResult.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 10: {
-                                message.presence_stats = $root.centrifugal.centrifuge.protocol.PresenceStatsResult.decode(reader, reader.uint32());
+                                message.presence_stats = $root.centrifugal.centrifuge.protocol.PresenceStatsResult.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 11: {
-                                message.history = $root.centrifugal.centrifuge.protocol.HistoryResult.decode(reader, reader.uint32());
+                                message.history = $root.centrifugal.centrifuge.protocol.HistoryResult.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 12: {
-                                message.ping = $root.centrifugal.centrifuge.protocol.PingResult.decode(reader, reader.uint32());
+                                message.ping = $root.centrifugal.centrifuge.protocol.PingResult.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 13: {
-                                message.rpc = $root.centrifugal.centrifuge.protocol.RPCResult.decode(reader, reader.uint32());
+                                message.rpc = $root.centrifugal.centrifuge.protocol.RPCResult.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 14: {
-                                message.refresh = $root.centrifugal.centrifuge.protocol.RefreshResult.decode(reader, reader.uint32());
+                                message.refresh = $root.centrifugal.centrifuge.protocol.RefreshResult.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 15: {
-                                message.sub_refresh = $root.centrifugal.centrifuge.protocol.SubRefreshResult.decode(reader, reader.uint32());
+                                message.sub_refresh = $root.centrifugal.centrifuge.protocol.SubRefreshResult.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -1086,74 +1122,78 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                Reply.verify = function verify(message) {
+                Reply.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.id != null && message.hasOwnProperty("id"))
                         if (!$util.isInteger(message.id))
                             return "id: integer expected";
                     if (message.error != null && message.hasOwnProperty("error")) {
-                        let error = $root.centrifugal.centrifuge.protocol.Error.verify(message.error);
+                        let error = $root.centrifugal.centrifuge.protocol.Error.verify(message.error, long + 1);
                         if (error)
                             return "error." + error;
                     }
                     if (message.push != null && message.hasOwnProperty("push")) {
-                        let error = $root.centrifugal.centrifuge.protocol.Push.verify(message.push);
+                        let error = $root.centrifugal.centrifuge.protocol.Push.verify(message.push, long + 1);
                         if (error)
                             return "push." + error;
                     }
                     if (message.connect != null && message.hasOwnProperty("connect")) {
-                        let error = $root.centrifugal.centrifuge.protocol.ConnectResult.verify(message.connect);
+                        let error = $root.centrifugal.centrifuge.protocol.ConnectResult.verify(message.connect, long + 1);
                         if (error)
                             return "connect." + error;
                     }
                     if (message.subscribe != null && message.hasOwnProperty("subscribe")) {
-                        let error = $root.centrifugal.centrifuge.protocol.SubscribeResult.verify(message.subscribe);
+                        let error = $root.centrifugal.centrifuge.protocol.SubscribeResult.verify(message.subscribe, long + 1);
                         if (error)
                             return "subscribe." + error;
                     }
                     if (message.unsubscribe != null && message.hasOwnProperty("unsubscribe")) {
-                        let error = $root.centrifugal.centrifuge.protocol.UnsubscribeResult.verify(message.unsubscribe);
+                        let error = $root.centrifugal.centrifuge.protocol.UnsubscribeResult.verify(message.unsubscribe, long + 1);
                         if (error)
                             return "unsubscribe." + error;
                     }
                     if (message.publish != null && message.hasOwnProperty("publish")) {
-                        let error = $root.centrifugal.centrifuge.protocol.PublishResult.verify(message.publish);
+                        let error = $root.centrifugal.centrifuge.protocol.PublishResult.verify(message.publish, long + 1);
                         if (error)
                             return "publish." + error;
                     }
                     if (message.presence != null && message.hasOwnProperty("presence")) {
-                        let error = $root.centrifugal.centrifuge.protocol.PresenceResult.verify(message.presence);
+                        let error = $root.centrifugal.centrifuge.protocol.PresenceResult.verify(message.presence, long + 1);
                         if (error)
                             return "presence." + error;
                     }
                     if (message.presence_stats != null && message.hasOwnProperty("presence_stats")) {
-                        let error = $root.centrifugal.centrifuge.protocol.PresenceStatsResult.verify(message.presence_stats);
+                        let error = $root.centrifugal.centrifuge.protocol.PresenceStatsResult.verify(message.presence_stats, long + 1);
                         if (error)
                             return "presence_stats." + error;
                     }
                     if (message.history != null && message.hasOwnProperty("history")) {
-                        let error = $root.centrifugal.centrifuge.protocol.HistoryResult.verify(message.history);
+                        let error = $root.centrifugal.centrifuge.protocol.HistoryResult.verify(message.history, long + 1);
                         if (error)
                             return "history." + error;
                     }
                     if (message.ping != null && message.hasOwnProperty("ping")) {
-                        let error = $root.centrifugal.centrifuge.protocol.PingResult.verify(message.ping);
+                        let error = $root.centrifugal.centrifuge.protocol.PingResult.verify(message.ping, long + 1);
                         if (error)
                             return "ping." + error;
                     }
                     if (message.rpc != null && message.hasOwnProperty("rpc")) {
-                        let error = $root.centrifugal.centrifuge.protocol.RPCResult.verify(message.rpc);
+                        let error = $root.centrifugal.centrifuge.protocol.RPCResult.verify(message.rpc, long + 1);
                         if (error)
                             return "rpc." + error;
                     }
                     if (message.refresh != null && message.hasOwnProperty("refresh")) {
-                        let error = $root.centrifugal.centrifuge.protocol.RefreshResult.verify(message.refresh);
+                        let error = $root.centrifugal.centrifuge.protocol.RefreshResult.verify(message.refresh, long + 1);
                         if (error)
                             return "refresh." + error;
                     }
                     if (message.sub_refresh != null && message.hasOwnProperty("sub_refresh")) {
-                        let error = $root.centrifugal.centrifuge.protocol.SubRefreshResult.verify(message.sub_refresh);
+                        let error = $root.centrifugal.centrifuge.protocol.SubRefreshResult.verify(message.sub_refresh, long + 1);
                         if (error)
                             return "sub_refresh." + error;
                     }
@@ -1195,6 +1235,7 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @property {centrifugal.centrifuge.protocol.IConnect|null} [connect] Push connect
                  * @property {centrifugal.centrifuge.protocol.IDisconnect|null} [disconnect] Push disconnect
                  * @property {centrifugal.centrifuge.protocol.IRefresh|null} [refresh] Push refresh
+                 * @property {centrifugal.centrifuge.protocol.IConnectionState|null} [state] Push state
                  */
 
                 /**
@@ -1208,7 +1249,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function Push(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -1301,6 +1342,14 @@ export const centrifugal = $root.centrifugal = (() => {
                 Push.prototype.refresh = null;
 
                 /**
+                 * Push state.
+                 * @member {centrifugal.centrifuge.protocol.IConnectionState|null|undefined} state
+                 * @memberof centrifugal.centrifuge.protocol.Push
+                 * @instance
+                 */
+                Push.prototype.state = null;
+
+                /**
                  * Encodes the specified Push message. Does not implicitly {@link centrifugal.centrifuge.protocol.Push.verify|verify} messages.
                  * @function encode
                  * @memberof centrifugal.centrifuge.protocol.Push
@@ -1334,6 +1383,8 @@ export const centrifugal = $root.centrifugal = (() => {
                         $root.centrifugal.centrifuge.protocol.Disconnect.encode(message.disconnect, writer.uint32(/* id 11, wireType 2 =*/90).fork()).ldelim();
                     if (message.refresh != null && Object.hasOwnProperty.call(message, "refresh"))
                         $root.centrifugal.centrifuge.protocol.Refresh.encode(message.refresh, writer.uint32(/* id 12, wireType 2 =*/98).fork()).ldelim();
+                    if (message.state != null && Object.hasOwnProperty.call(message, "state"))
+                        $root.centrifugal.centrifuge.protocol.ConnectionState.encode(message.state, writer.uint32(/* id 13, wireType 2 =*/106).fork()).ldelim();
                     return writer;
                 };
 
@@ -1361,12 +1412,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                Push.decode = function decode(reader, length) {
+                Push.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.Push();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.id = reader.int64();
@@ -1377,43 +1434,47 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         case 4: {
-                                message.pub = $root.centrifugal.centrifuge.protocol.Publication.decode(reader, reader.uint32());
+                                message.pub = $root.centrifugal.centrifuge.protocol.Publication.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 5: {
-                                message.join = $root.centrifugal.centrifuge.protocol.Join.decode(reader, reader.uint32());
+                                message.join = $root.centrifugal.centrifuge.protocol.Join.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 6: {
-                                message.leave = $root.centrifugal.centrifuge.protocol.Leave.decode(reader, reader.uint32());
+                                message.leave = $root.centrifugal.centrifuge.protocol.Leave.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 7: {
-                                message.unsubscribe = $root.centrifugal.centrifuge.protocol.Unsubscribe.decode(reader, reader.uint32());
+                                message.unsubscribe = $root.centrifugal.centrifuge.protocol.Unsubscribe.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 8: {
-                                message.message = $root.centrifugal.centrifuge.protocol.Message.decode(reader, reader.uint32());
+                                message.message = $root.centrifugal.centrifuge.protocol.Message.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 9: {
-                                message.subscribe = $root.centrifugal.centrifuge.protocol.Subscribe.decode(reader, reader.uint32());
+                                message.subscribe = $root.centrifugal.centrifuge.protocol.Subscribe.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 10: {
-                                message.connect = $root.centrifugal.centrifuge.protocol.Connect.decode(reader, reader.uint32());
+                                message.connect = $root.centrifugal.centrifuge.protocol.Connect.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 11: {
-                                message.disconnect = $root.centrifugal.centrifuge.protocol.Disconnect.decode(reader, reader.uint32());
+                                message.disconnect = $root.centrifugal.centrifuge.protocol.Disconnect.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 12: {
-                                message.refresh = $root.centrifugal.centrifuge.protocol.Refresh.decode(reader, reader.uint32());
+                                message.refresh = $root.centrifugal.centrifuge.protocol.Refresh.decode(reader, reader.uint32(), undefined, long + 1);
+                                break;
+                            }
+                        case 13: {
+                                message.state = $root.centrifugal.centrifuge.protocol.ConnectionState.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -1444,9 +1505,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                Push.verify = function verify(message) {
+                Push.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.id != null && message.hasOwnProperty("id"))
                         if (!$util.isInteger(message.id) && !(message.id && $util.isInteger(message.id.low) && $util.isInteger(message.id.high)))
                             return "id: integer|Long expected";
@@ -1454,49 +1519,54 @@ export const centrifugal = $root.centrifugal = (() => {
                         if (!$util.isString(message.channel))
                             return "channel: string expected";
                     if (message.pub != null && message.hasOwnProperty("pub")) {
-                        let error = $root.centrifugal.centrifuge.protocol.Publication.verify(message.pub);
+                        let error = $root.centrifugal.centrifuge.protocol.Publication.verify(message.pub, long + 1);
                         if (error)
                             return "pub." + error;
                     }
                     if (message.join != null && message.hasOwnProperty("join")) {
-                        let error = $root.centrifugal.centrifuge.protocol.Join.verify(message.join);
+                        let error = $root.centrifugal.centrifuge.protocol.Join.verify(message.join, long + 1);
                         if (error)
                             return "join." + error;
                     }
                     if (message.leave != null && message.hasOwnProperty("leave")) {
-                        let error = $root.centrifugal.centrifuge.protocol.Leave.verify(message.leave);
+                        let error = $root.centrifugal.centrifuge.protocol.Leave.verify(message.leave, long + 1);
                         if (error)
                             return "leave." + error;
                     }
                     if (message.unsubscribe != null && message.hasOwnProperty("unsubscribe")) {
-                        let error = $root.centrifugal.centrifuge.protocol.Unsubscribe.verify(message.unsubscribe);
+                        let error = $root.centrifugal.centrifuge.protocol.Unsubscribe.verify(message.unsubscribe, long + 1);
                         if (error)
                             return "unsubscribe." + error;
                     }
                     if (message.message != null && message.hasOwnProperty("message")) {
-                        let error = $root.centrifugal.centrifuge.protocol.Message.verify(message.message);
+                        let error = $root.centrifugal.centrifuge.protocol.Message.verify(message.message, long + 1);
                         if (error)
                             return "message." + error;
                     }
                     if (message.subscribe != null && message.hasOwnProperty("subscribe")) {
-                        let error = $root.centrifugal.centrifuge.protocol.Subscribe.verify(message.subscribe);
+                        let error = $root.centrifugal.centrifuge.protocol.Subscribe.verify(message.subscribe, long + 1);
                         if (error)
                             return "subscribe." + error;
                     }
                     if (message.connect != null && message.hasOwnProperty("connect")) {
-                        let error = $root.centrifugal.centrifuge.protocol.Connect.verify(message.connect);
+                        let error = $root.centrifugal.centrifuge.protocol.Connect.verify(message.connect, long + 1);
                         if (error)
                             return "connect." + error;
                     }
                     if (message.disconnect != null && message.hasOwnProperty("disconnect")) {
-                        let error = $root.centrifugal.centrifuge.protocol.Disconnect.verify(message.disconnect);
+                        let error = $root.centrifugal.centrifuge.protocol.Disconnect.verify(message.disconnect, long + 1);
                         if (error)
                             return "disconnect." + error;
                     }
                     if (message.refresh != null && message.hasOwnProperty("refresh")) {
-                        let error = $root.centrifugal.centrifuge.protocol.Refresh.verify(message.refresh);
+                        let error = $root.centrifugal.centrifuge.protocol.Refresh.verify(message.refresh, long + 1);
                         if (error)
                             return "refresh." + error;
+                    }
+                    if (message.state != null && message.hasOwnProperty("state")) {
+                        let error = $root.centrifugal.centrifuge.protocol.ConnectionState.verify(message.state, long + 1);
+                        if (error)
+                            return "state." + error;
                     }
                     return null;
                 };
@@ -1517,6 +1587,350 @@ export const centrifugal = $root.centrifugal = (() => {
                 };
 
                 return Push;
+            })();
+
+            protocol.ConnectionState = (function() {
+
+                /**
+                 * Properties of a ConnectionState.
+                 * @memberof centrifugal.centrifuge.protocol
+                 * @interface IConnectionState
+                 * @property {centrifugal.centrifuge.protocol.IDictionary|null} [dictionary] ConnectionState dictionary
+                 */
+
+                /**
+                 * Constructs a new ConnectionState.
+                 * @memberof centrifugal.centrifuge.protocol
+                 * @classdesc Represents a ConnectionState.
+                 * @implements IConnectionState
+                 * @constructor
+                 * @param {centrifugal.centrifuge.protocol.IConnectionState=} [properties] Properties to set
+                 */
+                function ConnectionState(properties) {
+                    if (properties)
+                        for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
+                                this[keys[i]] = properties[keys[i]];
+                }
+
+                /**
+                 * ConnectionState dictionary.
+                 * @member {centrifugal.centrifuge.protocol.IDictionary|null|undefined} dictionary
+                 * @memberof centrifugal.centrifuge.protocol.ConnectionState
+                 * @instance
+                 */
+                ConnectionState.prototype.dictionary = null;
+
+                /**
+                 * Encodes the specified ConnectionState message. Does not implicitly {@link centrifugal.centrifuge.protocol.ConnectionState.verify|verify} messages.
+                 * @function encode
+                 * @memberof centrifugal.centrifuge.protocol.ConnectionState
+                 * @static
+                 * @param {centrifugal.centrifuge.protocol.IConnectionState} message ConnectionState message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                ConnectionState.encode = function encode(message, writer) {
+                    if (!writer)
+                        writer = $Writer.create();
+                    if (message.dictionary != null && Object.hasOwnProperty.call(message, "dictionary"))
+                        $root.centrifugal.centrifuge.protocol.Dictionary.encode(message.dictionary, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                    return writer;
+                };
+
+                /**
+                 * Encodes the specified ConnectionState message, length delimited. Does not implicitly {@link centrifugal.centrifuge.protocol.ConnectionState.verify|verify} messages.
+                 * @function encodeDelimited
+                 * @memberof centrifugal.centrifuge.protocol.ConnectionState
+                 * @static
+                 * @param {centrifugal.centrifuge.protocol.IConnectionState} message ConnectionState message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                ConnectionState.encodeDelimited = function encodeDelimited(message, writer) {
+                    return this.encode(message, writer).ldelim();
+                };
+
+                /**
+                 * Decodes a ConnectionState message from the specified reader or buffer.
+                 * @function decode
+                 * @memberof centrifugal.centrifuge.protocol.ConnectionState
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @param {number} [length] Message length if known beforehand
+                 * @returns {centrifugal.centrifuge.protocol.ConnectionState} ConnectionState
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                ConnectionState.decode = function decode(reader, length, error, long) {
+                    if (!(reader instanceof $Reader))
+                        reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
+                    let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.ConnectionState();
+                    while (reader.pos < end) {
+                        let tag = reader.uint32();
+                        if (tag === error)
+                            break;
+                        switch (tag >>> 3) {
+                        case 1: {
+                                message.dictionary = $root.centrifugal.centrifuge.protocol.Dictionary.decode(reader, reader.uint32(), undefined, long + 1);
+                                break;
+                            }
+                        default:
+                            reader.skipType(tag & 7, long);
+                            break;
+                        }
+                    }
+                    return message;
+                };
+
+                /**
+                 * Decodes a ConnectionState message from the specified reader or buffer, length delimited.
+                 * @function decodeDelimited
+                 * @memberof centrifugal.centrifuge.protocol.ConnectionState
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @returns {centrifugal.centrifuge.protocol.ConnectionState} ConnectionState
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                ConnectionState.decodeDelimited = function decodeDelimited(reader) {
+                    if (!(reader instanceof $Reader))
+                        reader = new $Reader(reader);
+                    return this.decode(reader, reader.uint32());
+                };
+
+                /**
+                 * Verifies a ConnectionState message.
+                 * @function verify
+                 * @memberof centrifugal.centrifuge.protocol.ConnectionState
+                 * @static
+                 * @param {Object.<string,*>} message Plain object to verify
+                 * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                 */
+                ConnectionState.verify = function verify(message, long) {
+                    if (typeof message !== "object" || message === null)
+                        return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
+                    if (message.dictionary != null && message.hasOwnProperty("dictionary")) {
+                        let error = $root.centrifugal.centrifuge.protocol.Dictionary.verify(message.dictionary, long + 1);
+                        if (error)
+                            return "dictionary." + error;
+                    }
+                    return null;
+                };
+
+                /**
+                 * Gets the default type url for ConnectionState
+                 * @function getTypeUrl
+                 * @memberof centrifugal.centrifuge.protocol.ConnectionState
+                 * @static
+                 * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+                 * @returns {string} The default type url
+                 */
+                ConnectionState.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+                    if (typeUrlPrefix === undefined) {
+                        typeUrlPrefix = "type.googleapis.com";
+                    }
+                    return typeUrlPrefix + "/centrifugal.centrifuge.protocol.ConnectionState";
+                };
+
+                return ConnectionState;
+            })();
+
+            protocol.Dictionary = (function() {
+
+                /**
+                 * Properties of a Dictionary.
+                 * @memberof centrifugal.centrifuge.protocol
+                 * @interface IDictionary
+                 * @property {string|null} [id] Dictionary id
+                 * @property {Uint8Array|null} [data] Dictionary data
+                 * @property {string|null} [data_b64] Dictionary data_b64
+                 */
+
+                /**
+                 * Constructs a new Dictionary.
+                 * @memberof centrifugal.centrifuge.protocol
+                 * @classdesc Represents a Dictionary.
+                 * @implements IDictionary
+                 * @constructor
+                 * @param {centrifugal.centrifuge.protocol.IDictionary=} [properties] Properties to set
+                 */
+                function Dictionary(properties) {
+                    if (properties)
+                        for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
+                                this[keys[i]] = properties[keys[i]];
+                }
+
+                /**
+                 * Dictionary id.
+                 * @member {string} id
+                 * @memberof centrifugal.centrifuge.protocol.Dictionary
+                 * @instance
+                 */
+                Dictionary.prototype.id = "";
+
+                /**
+                 * Dictionary data.
+                 * @member {Uint8Array} data
+                 * @memberof centrifugal.centrifuge.protocol.Dictionary
+                 * @instance
+                 */
+                Dictionary.prototype.data = $util.newBuffer([]);
+
+                /**
+                 * Dictionary data_b64.
+                 * @member {string} data_b64
+                 * @memberof centrifugal.centrifuge.protocol.Dictionary
+                 * @instance
+                 */
+                Dictionary.prototype.data_b64 = "";
+
+                /**
+                 * Encodes the specified Dictionary message. Does not implicitly {@link centrifugal.centrifuge.protocol.Dictionary.verify|verify} messages.
+                 * @function encode
+                 * @memberof centrifugal.centrifuge.protocol.Dictionary
+                 * @static
+                 * @param {centrifugal.centrifuge.protocol.IDictionary} message Dictionary message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                Dictionary.encode = function encode(message, writer) {
+                    if (!writer)
+                        writer = $Writer.create();
+                    if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                        writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                    if (message.data != null && Object.hasOwnProperty.call(message, "data"))
+                        writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.data);
+                    if (message.data_b64 != null && Object.hasOwnProperty.call(message, "data_b64"))
+                        writer.uint32(/* id 3, wireType 2 =*/26).string(message.data_b64);
+                    return writer;
+                };
+
+                /**
+                 * Encodes the specified Dictionary message, length delimited. Does not implicitly {@link centrifugal.centrifuge.protocol.Dictionary.verify|verify} messages.
+                 * @function encodeDelimited
+                 * @memberof centrifugal.centrifuge.protocol.Dictionary
+                 * @static
+                 * @param {centrifugal.centrifuge.protocol.IDictionary} message Dictionary message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                Dictionary.encodeDelimited = function encodeDelimited(message, writer) {
+                    return this.encode(message, writer).ldelim();
+                };
+
+                /**
+                 * Decodes a Dictionary message from the specified reader or buffer.
+                 * @function decode
+                 * @memberof centrifugal.centrifuge.protocol.Dictionary
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @param {number} [length] Message length if known beforehand
+                 * @returns {centrifugal.centrifuge.protocol.Dictionary} Dictionary
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                Dictionary.decode = function decode(reader, length, error, long) {
+                    if (!(reader instanceof $Reader))
+                        reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
+                    let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.Dictionary();
+                    while (reader.pos < end) {
+                        let tag = reader.uint32();
+                        if (tag === error)
+                            break;
+                        switch (tag >>> 3) {
+                        case 1: {
+                                message.id = reader.string();
+                                break;
+                            }
+                        case 2: {
+                                message.data = reader.bytes();
+                                break;
+                            }
+                        case 3: {
+                                message.data_b64 = reader.string();
+                                break;
+                            }
+                        default:
+                            reader.skipType(tag & 7, long);
+                            break;
+                        }
+                    }
+                    return message;
+                };
+
+                /**
+                 * Decodes a Dictionary message from the specified reader or buffer, length delimited.
+                 * @function decodeDelimited
+                 * @memberof centrifugal.centrifuge.protocol.Dictionary
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @returns {centrifugal.centrifuge.protocol.Dictionary} Dictionary
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                Dictionary.decodeDelimited = function decodeDelimited(reader) {
+                    if (!(reader instanceof $Reader))
+                        reader = new $Reader(reader);
+                    return this.decode(reader, reader.uint32());
+                };
+
+                /**
+                 * Verifies a Dictionary message.
+                 * @function verify
+                 * @memberof centrifugal.centrifuge.protocol.Dictionary
+                 * @static
+                 * @param {Object.<string,*>} message Plain object to verify
+                 * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                 */
+                Dictionary.verify = function verify(message, long) {
+                    if (typeof message !== "object" || message === null)
+                        return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
+                    if (message.id != null && message.hasOwnProperty("id"))
+                        if (!$util.isString(message.id))
+                            return "id: string expected";
+                    if (message.data != null && message.hasOwnProperty("data"))
+                        if (!(message.data && typeof message.data.length === "number" || $util.isString(message.data)))
+                            return "data: buffer expected";
+                    if (message.data_b64 != null && message.hasOwnProperty("data_b64"))
+                        if (!$util.isString(message.data_b64))
+                            return "data_b64: string expected";
+                    return null;
+                };
+
+                /**
+                 * Gets the default type url for Dictionary
+                 * @function getTypeUrl
+                 * @memberof centrifugal.centrifuge.protocol.Dictionary
+                 * @static
+                 * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+                 * @returns {string} The default type url
+                 */
+                Dictionary.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+                    if (typeUrlPrefix === undefined) {
+                        typeUrlPrefix = "type.googleapis.com";
+                    }
+                    return typeUrlPrefix + "/centrifugal.centrifuge.protocol.Dictionary";
+                };
+
+                return Dictionary;
             })();
 
             protocol.ClientInfo = (function() {
@@ -1542,7 +1956,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function ClientInfo(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -1625,12 +2039,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                ClientInfo.decode = function decode(reader, length) {
+                ClientInfo.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.ClientInfo();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.user = reader.string();
@@ -1649,7 +2069,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -1680,9 +2100,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                ClientInfo.verify = function verify(message) {
+                ClientInfo.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.user != null && message.hasOwnProperty("user"))
                         if (!$util.isString(message.user))
                             return "user: string expected";
@@ -1749,7 +2173,7 @@ export const centrifugal = $root.centrifugal = (() => {
                     this.tags = {};
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -1923,19 +2347,25 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                Publication.decode = function decode(reader, length) {
+                Publication.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.Publication(), key, value;
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 4: {
                                 message.data = reader.bytes();
                                 break;
                             }
                         case 5: {
-                                message.info = $root.centrifugal.centrifuge.protocol.ClientInfo.decode(reader, reader.uint32());
+                                message.info = $root.centrifugal.centrifuge.protocol.ClientInfo.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 6: {
@@ -1958,10 +2388,12 @@ export const centrifugal = $root.centrifugal = (() => {
                                         value = reader.string();
                                         break;
                                     default:
-                                        reader.skipType(tag2 & 7);
+                                        reader.skipType(tag2 & 7, long);
                                         break;
                                     }
                                 }
+                                if (key === "__proto__")
+                                    $util.makeProp(message.tags, key);
                                 message.tags[key] = value;
                                 break;
                             }
@@ -2002,7 +2434,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -2033,14 +2465,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                Publication.verify = function verify(message) {
+                Publication.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.data != null && message.hasOwnProperty("data"))
                         if (!(message.data && typeof message.data.length === "number" || $util.isString(message.data)))
                             return "data: buffer expected";
                     if (message.info != null && message.hasOwnProperty("info")) {
-                        let error = $root.centrifugal.centrifuge.protocol.ClientInfo.verify(message.info);
+                        let error = $root.centrifugal.centrifuge.protocol.ClientInfo.verify(message.info, long + 1);
                         if (error)
                             return "info." + error;
                     }
@@ -2123,7 +2559,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function Join(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -2176,19 +2612,25 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                Join.decode = function decode(reader, length) {
+                Join.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.Join();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
-                                message.info = $root.centrifugal.centrifuge.protocol.ClientInfo.decode(reader, reader.uint32());
+                                message.info = $root.centrifugal.centrifuge.protocol.ClientInfo.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -2219,11 +2661,15 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                Join.verify = function verify(message) {
+                Join.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.info != null && message.hasOwnProperty("info")) {
-                        let error = $root.centrifugal.centrifuge.protocol.ClientInfo.verify(message.info);
+                        let error = $root.centrifugal.centrifuge.protocol.ClientInfo.verify(message.info, long + 1);
                         if (error)
                             return "info." + error;
                     }
@@ -2268,7 +2714,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function Leave(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -2321,19 +2767,25 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                Leave.decode = function decode(reader, length) {
+                Leave.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.Leave();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
-                                message.info = $root.centrifugal.centrifuge.protocol.ClientInfo.decode(reader, reader.uint32());
+                                message.info = $root.centrifugal.centrifuge.protocol.ClientInfo.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -2364,11 +2816,15 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                Leave.verify = function verify(message) {
+                Leave.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.info != null && message.hasOwnProperty("info")) {
-                        let error = $root.centrifugal.centrifuge.protocol.ClientInfo.verify(message.info);
+                        let error = $root.centrifugal.centrifuge.protocol.ClientInfo.verify(message.info, long + 1);
                         if (error)
                             return "info." + error;
                     }
@@ -2414,7 +2870,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function Unsubscribe(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -2477,12 +2933,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                Unsubscribe.decode = function decode(reader, length) {
+                Unsubscribe.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.Unsubscribe();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 2: {
                                 message.code = reader.uint32();
@@ -2493,7 +2955,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -2524,9 +2986,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                Unsubscribe.verify = function verify(message) {
+                Unsubscribe.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.code != null && message.hasOwnProperty("code"))
                         if (!$util.isInteger(message.code))
                             return "code: integer expected";
@@ -2578,7 +3044,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function Subscribe(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -2671,12 +3137,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                Subscribe.decode = function decode(reader, length) {
+                Subscribe.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.Subscribe();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.recoverable = reader.bool();
@@ -2699,7 +3171,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -2730,9 +3202,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                Subscribe.verify = function verify(message) {
+                Subscribe.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.recoverable != null && message.hasOwnProperty("recoverable"))
                         if (typeof message.recoverable !== "boolean")
                             return "recoverable: boolean expected";
@@ -2789,7 +3265,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function Message(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -2842,19 +3318,25 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                Message.decode = function decode(reader, length) {
+                Message.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.Message();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.data = reader.bytes();
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -2885,9 +3367,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                Message.verify = function verify(message) {
+                Message.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.data != null && message.hasOwnProperty("data"))
                         if (!(message.data && typeof message.data.length === "number" || $util.isString(message.data)))
                             return "data: buffer expected";
@@ -2943,7 +3429,7 @@ export const centrifugal = $root.centrifugal = (() => {
                     this.subs = {};
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -3099,12 +3585,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                Connect.decode = function decode(reader, length) {
+                Connect.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.Connect(), key, value;
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.client = reader.string();
@@ -3131,13 +3623,15 @@ export const centrifugal = $root.centrifugal = (() => {
                                         key = reader.string();
                                         break;
                                     case 2:
-                                        value = $root.centrifugal.centrifuge.protocol.SubscribeResult.decode(reader, reader.uint32());
+                                        value = $root.centrifugal.centrifuge.protocol.SubscribeResult.decode(reader, reader.uint32(), undefined, long + 1);
                                         break;
                                     default:
-                                        reader.skipType(tag2 & 7);
+                                        reader.skipType(tag2 & 7, long);
                                         break;
                                     }
                                 }
+                                if (key === "__proto__")
+                                    $util.makeProp(message.subs, key);
                                 message.subs[key] = value;
                                 break;
                             }
@@ -3170,7 +3664,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -3201,9 +3695,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                Connect.verify = function verify(message) {
+                Connect.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.client != null && message.hasOwnProperty("client"))
                         if (!$util.isString(message.client))
                             return "client: string expected";
@@ -3218,7 +3716,7 @@ export const centrifugal = $root.centrifugal = (() => {
                             return "subs: object expected";
                         let key = Object.keys(message.subs);
                         for (let i = 0; i < key.length; ++i) {
-                            let error = $root.centrifugal.centrifuge.protocol.SubscribeResult.verify(message.subs[key[i]]);
+                            let error = $root.centrifugal.centrifuge.protocol.SubscribeResult.verify(message.subs[key[i]], long + 1);
                             if (error)
                                 return "subs." + error;
                         }
@@ -3287,7 +3785,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function Disconnect(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -3360,12 +3858,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                Disconnect.decode = function decode(reader, length) {
+                Disconnect.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.Disconnect();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.code = reader.uint32();
@@ -3380,7 +3884,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -3411,9 +3915,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                Disconnect.verify = function verify(message) {
+                Disconnect.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.code != null && message.hasOwnProperty("code"))
                         if (!$util.isInteger(message.code))
                             return "code: integer expected";
@@ -3465,7 +3973,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function Refresh(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -3528,12 +4036,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                Refresh.decode = function decode(reader, length) {
+                Refresh.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.Refresh();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.expires = reader.bool();
@@ -3544,7 +4058,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -3575,9 +4089,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                Refresh.verify = function verify(message) {
+                Refresh.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.expires != null && message.hasOwnProperty("expires"))
                         if (typeof message.expires !== "boolean")
                             return "expires: boolean expected";
@@ -3633,7 +4151,7 @@ export const centrifugal = $root.centrifugal = (() => {
                     this.headers = {};
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -3750,12 +4268,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                ConnectRequest.decode = function decode(reader, length) {
+                ConnectRequest.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.ConnectRequest(), key, value;
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.token = reader.string();
@@ -3778,13 +4302,15 @@ export const centrifugal = $root.centrifugal = (() => {
                                         key = reader.string();
                                         break;
                                     case 2:
-                                        value = $root.centrifugal.centrifuge.protocol.SubscribeRequest.decode(reader, reader.uint32());
+                                        value = $root.centrifugal.centrifuge.protocol.SubscribeRequest.decode(reader, reader.uint32(), undefined, long + 1);
                                         break;
                                     default:
-                                        reader.skipType(tag2 & 7);
+                                        reader.skipType(tag2 & 7, long);
                                         break;
                                     }
                                 }
+                                if (key === "__proto__")
+                                    $util.makeProp(message.subs, key);
                                 message.subs[key] = value;
                                 break;
                             }
@@ -3812,10 +4338,12 @@ export const centrifugal = $root.centrifugal = (() => {
                                         value = reader.string();
                                         break;
                                     default:
-                                        reader.skipType(tag2 & 7);
+                                        reader.skipType(tag2 & 7, long);
                                         break;
                                     }
                                 }
+                                if (key === "__proto__")
+                                    $util.makeProp(message.headers, key);
                                 message.headers[key] = value;
                                 break;
                             }
@@ -3824,7 +4352,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -3855,9 +4383,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                ConnectRequest.verify = function verify(message) {
+                ConnectRequest.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.token != null && message.hasOwnProperty("token"))
                         if (!$util.isString(message.token))
                             return "token: string expected";
@@ -3869,7 +4401,7 @@ export const centrifugal = $root.centrifugal = (() => {
                             return "subs: object expected";
                         let key = Object.keys(message.subs);
                         for (let i = 0; i < key.length; ++i) {
-                            let error = $root.centrifugal.centrifuge.protocol.SubscribeRequest.verify(message.subs[key[i]]);
+                            let error = $root.centrifugal.centrifuge.protocol.SubscribeRequest.verify(message.subs[key[i]], long + 1);
                             if (error)
                                 return "subs." + error;
                         }
@@ -3929,6 +4461,7 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @property {string|null} [session] ConnectResult session
                  * @property {string|null} [node] ConnectResult node
                  * @property {number|Long|null} [time] ConnectResult time
+                 * @property {number|Long|null} [flag] ConnectResult flag
                  */
 
                 /**
@@ -3943,7 +4476,7 @@ export const centrifugal = $root.centrifugal = (() => {
                     this.subs = {};
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -4036,6 +4569,14 @@ export const centrifugal = $root.centrifugal = (() => {
                 ConnectResult.prototype.time = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
                 /**
+                 * ConnectResult flag.
+                 * @member {number|Long} flag
+                 * @memberof centrifugal.centrifuge.protocol.ConnectResult
+                 * @instance
+                 */
+                ConnectResult.prototype.flag = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+
+                /**
                  * Encodes the specified ConnectResult message. Does not implicitly {@link centrifugal.centrifuge.protocol.ConnectResult.verify|verify} messages.
                  * @function encode
                  * @memberof centrifugal.centrifuge.protocol.ConnectResult
@@ -4072,6 +4613,8 @@ export const centrifugal = $root.centrifugal = (() => {
                         writer.uint32(/* id 10, wireType 2 =*/82).string(message.node);
                     if (message.time != null && Object.hasOwnProperty.call(message, "time"))
                         writer.uint32(/* id 11, wireType 0 =*/88).int64(message.time);
+                    if (message.flag != null && Object.hasOwnProperty.call(message, "flag"))
+                        writer.uint32(/* id 12, wireType 0 =*/96).int64(message.flag);
                     return writer;
                 };
 
@@ -4099,12 +4642,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                ConnectResult.decode = function decode(reader, length) {
+                ConnectResult.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.ConnectResult(), key, value;
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.client = reader.string();
@@ -4139,13 +4688,15 @@ export const centrifugal = $root.centrifugal = (() => {
                                         key = reader.string();
                                         break;
                                     case 2:
-                                        value = $root.centrifugal.centrifuge.protocol.SubscribeResult.decode(reader, reader.uint32());
+                                        value = $root.centrifugal.centrifuge.protocol.SubscribeResult.decode(reader, reader.uint32(), undefined, long + 1);
                                         break;
                                     default:
-                                        reader.skipType(tag2 & 7);
+                                        reader.skipType(tag2 & 7, long);
                                         break;
                                     }
                                 }
+                                if (key === "__proto__")
+                                    $util.makeProp(message.subs, key);
                                 message.subs[key] = value;
                                 break;
                             }
@@ -4169,8 +4720,12 @@ export const centrifugal = $root.centrifugal = (() => {
                                 message.time = reader.int64();
                                 break;
                             }
+                        case 12: {
+                                message.flag = reader.int64();
+                                break;
+                            }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -4201,9 +4756,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                ConnectResult.verify = function verify(message) {
+                ConnectResult.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.client != null && message.hasOwnProperty("client"))
                         if (!$util.isString(message.client))
                             return "client: string expected";
@@ -4224,7 +4783,7 @@ export const centrifugal = $root.centrifugal = (() => {
                             return "subs: object expected";
                         let key = Object.keys(message.subs);
                         for (let i = 0; i < key.length; ++i) {
-                            let error = $root.centrifugal.centrifuge.protocol.SubscribeResult.verify(message.subs[key[i]]);
+                            let error = $root.centrifugal.centrifuge.protocol.SubscribeResult.verify(message.subs[key[i]], long + 1);
                             if (error)
                                 return "subs." + error;
                         }
@@ -4244,6 +4803,9 @@ export const centrifugal = $root.centrifugal = (() => {
                     if (message.time != null && message.hasOwnProperty("time"))
                         if (!$util.isInteger(message.time) && !(message.time && $util.isInteger(message.time.low) && $util.isInteger(message.time.high)))
                             return "time: integer|Long expected";
+                    if (message.flag != null && message.hasOwnProperty("flag"))
+                        if (!$util.isInteger(message.flag) && !(message.flag && $util.isInteger(message.flag.low) && $util.isInteger(message.flag.high)))
+                            return "flag: integer|Long expected";
                     return null;
                 };
 
@@ -4285,7 +4847,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function RefreshRequest(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -4338,19 +4900,25 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                RefreshRequest.decode = function decode(reader, length) {
+                RefreshRequest.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.RefreshRequest();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.token = reader.string();
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -4381,9 +4949,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                RefreshRequest.verify = function verify(message) {
+                RefreshRequest.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.token != null && message.hasOwnProperty("token"))
                         if (!$util.isString(message.token))
                             return "token: string expected";
@@ -4431,7 +5003,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function RefreshResult(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -4514,12 +5086,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                RefreshResult.decode = function decode(reader, length) {
+                RefreshResult.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.RefreshResult();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.client = reader.string();
@@ -4538,7 +5116,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -4569,9 +5147,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                RefreshResult.verify = function verify(message) {
+                RefreshResult.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.client != null && message.hasOwnProperty("client"))
                         if (!$util.isString(message.client))
                             return "client: string expected";
@@ -4641,7 +5223,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function SubscribeRequest(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -4854,12 +5436,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                SubscribeRequest.decode = function decode(reader, length) {
+                SubscribeRequest.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.SubscribeRequest();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.channel = reader.string();
@@ -4902,7 +5490,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         case 13: {
-                                message.tf = $root.centrifugal.centrifuge.protocol.FilterNode.decode(reader, reader.uint32());
+                                message.tf = $root.centrifugal.centrifuge.protocol.FilterNode.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 14: {
@@ -4930,7 +5518,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -4961,9 +5549,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                SubscribeRequest.verify = function verify(message) {
+                SubscribeRequest.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.channel != null && message.hasOwnProperty("channel"))
                         if (!$util.isString(message.channel))
                             return "channel: string expected";
@@ -4995,7 +5587,7 @@ export const centrifugal = $root.centrifugal = (() => {
                         if (!$util.isString(message.delta))
                             return "delta: string expected";
                     if (message.tf != null && message.hasOwnProperty("tf")) {
-                        let error = $root.centrifugal.centrifuge.protocol.FilterNode.verify(message.tf);
+                        let error = $root.centrifugal.centrifuge.protocol.FilterNode.verify(message.tf, long + 1);
                         if (error)
                             return "tf." + error;
                     }
@@ -5076,7 +5668,7 @@ export const centrifugal = $root.centrifugal = (() => {
                     this.state = [];
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -5291,12 +5883,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                SubscribeResult.decode = function decode(reader, length) {
+                SubscribeResult.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.SubscribeResult();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.expires = reader.bool();
@@ -5317,7 +5915,7 @@ export const centrifugal = $root.centrifugal = (() => {
                         case 7: {
                                 if (!(message.publications && message.publications.length))
                                     message.publications = [];
-                                message.publications.push($root.centrifugal.centrifuge.protocol.Publication.decode(reader, reader.uint32()));
+                                message.publications.push($root.centrifugal.centrifuge.protocol.Publication.decode(reader, reader.uint32(), undefined, long + 1));
                                 break;
                             }
                         case 8: {
@@ -5363,7 +5961,7 @@ export const centrifugal = $root.centrifugal = (() => {
                         case 18: {
                                 if (!(message.state && message.state.length))
                                     message.state = [];
-                                message.state.push($root.centrifugal.centrifuge.protocol.Publication.decode(reader, reader.uint32()));
+                                message.state.push($root.centrifugal.centrifuge.protocol.Publication.decode(reader, reader.uint32(), undefined, long + 1));
                                 break;
                             }
                         case 19: {
@@ -5371,7 +5969,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -5402,9 +6000,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                SubscribeResult.verify = function verify(message) {
+                SubscribeResult.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.expires != null && message.hasOwnProperty("expires"))
                         if (typeof message.expires !== "boolean")
                             return "expires: boolean expected";
@@ -5421,7 +6023,7 @@ export const centrifugal = $root.centrifugal = (() => {
                         if (!Array.isArray(message.publications))
                             return "publications: array expected";
                         for (let i = 0; i < message.publications.length; ++i) {
-                            let error = $root.centrifugal.centrifuge.protocol.Publication.verify(message.publications[i]);
+                            let error = $root.centrifugal.centrifuge.protocol.Publication.verify(message.publications[i], long + 1);
                             if (error)
                                 return "publications." + error;
                         }
@@ -5460,7 +6062,7 @@ export const centrifugal = $root.centrifugal = (() => {
                         if (!Array.isArray(message.state))
                             return "state: array expected";
                         for (let i = 0; i < message.state.length; ++i) {
-                            let error = $root.centrifugal.centrifuge.protocol.Publication.verify(message.state[i]);
+                            let error = $root.centrifugal.centrifuge.protocol.Publication.verify(message.state[i], long + 1);
                             if (error)
                                 return "state." + error;
                         }
@@ -5510,7 +6112,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function KeyedItem(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -5573,12 +6175,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                KeyedItem.decode = function decode(reader, length) {
+                KeyedItem.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.KeyedItem();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.key = reader.string();
@@ -5589,7 +6197,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -5620,9 +6228,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                KeyedItem.verify = function verify(message) {
+                KeyedItem.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.key != null && message.hasOwnProperty("key"))
                         if (!$util.isString(message.key))
                             return "key: string expected";
@@ -5672,7 +6284,7 @@ export const centrifugal = $root.centrifugal = (() => {
                     this.items = [];
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -5736,12 +6348,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                TrackBatch.decode = function decode(reader, length) {
+                TrackBatch.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.TrackBatch();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.signature = reader.string();
@@ -5750,11 +6368,11 @@ export const centrifugal = $root.centrifugal = (() => {
                         case 2: {
                                 if (!(message.items && message.items.length))
                                     message.items = [];
-                                message.items.push($root.centrifugal.centrifuge.protocol.KeyedItem.decode(reader, reader.uint32()));
+                                message.items.push($root.centrifugal.centrifuge.protocol.KeyedItem.decode(reader, reader.uint32(), undefined, long + 1));
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -5785,9 +6403,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                TrackBatch.verify = function verify(message) {
+                TrackBatch.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.signature != null && message.hasOwnProperty("signature"))
                         if (!$util.isString(message.signature))
                             return "signature: string expected";
@@ -5795,7 +6417,7 @@ export const centrifugal = $root.centrifugal = (() => {
                         if (!Array.isArray(message.items))
                             return "items: array expected";
                         for (let i = 0; i < message.items.length; ++i) {
-                            let error = $root.centrifugal.centrifuge.protocol.KeyedItem.verify(message.items[i]);
+                            let error = $root.centrifugal.centrifuge.protocol.KeyedItem.verify(message.items[i], long + 1);
                             if (error)
                                 return "items." + error;
                         }
@@ -5847,7 +6469,7 @@ export const centrifugal = $root.centrifugal = (() => {
                     this.untrack = [];
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -5942,12 +6564,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                SubRefreshRequest.decode = function decode(reader, length) {
+                SubRefreshRequest.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.SubRefreshRequest();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.channel = reader.string();
@@ -5964,7 +6592,7 @@ export const centrifugal = $root.centrifugal = (() => {
                         case 4: {
                                 if (!(message.track && message.track.length))
                                     message.track = [];
-                                message.track.push($root.centrifugal.centrifuge.protocol.TrackBatch.decode(reader, reader.uint32()));
+                                message.track.push($root.centrifugal.centrifuge.protocol.TrackBatch.decode(reader, reader.uint32(), undefined, long + 1));
                                 break;
                             }
                         case 5: {
@@ -5974,7 +6602,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -6005,9 +6633,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                SubRefreshRequest.verify = function verify(message) {
+                SubRefreshRequest.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.channel != null && message.hasOwnProperty("channel"))
                         if (!$util.isString(message.channel))
                             return "channel: string expected";
@@ -6021,7 +6653,7 @@ export const centrifugal = $root.centrifugal = (() => {
                         if (!Array.isArray(message.track))
                             return "track: array expected";
                         for (let i = 0; i < message.track.length; ++i) {
-                            let error = $root.centrifugal.centrifuge.protocol.TrackBatch.verify(message.track[i]);
+                            let error = $root.centrifugal.centrifuge.protocol.TrackBatch.verify(message.track[i], long + 1);
                             if (error)
                                 return "track." + error;
                         }
@@ -6077,7 +6709,7 @@ export const centrifugal = $root.centrifugal = (() => {
                     this.items = [];
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -6151,12 +6783,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                SubRefreshResult.decode = function decode(reader, length) {
+                SubRefreshResult.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.SubRefreshResult();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.expires = reader.bool();
@@ -6169,11 +6807,11 @@ export const centrifugal = $root.centrifugal = (() => {
                         case 3: {
                                 if (!(message.items && message.items.length))
                                     message.items = [];
-                                message.items.push($root.centrifugal.centrifuge.protocol.Publication.decode(reader, reader.uint32()));
+                                message.items.push($root.centrifugal.centrifuge.protocol.Publication.decode(reader, reader.uint32(), undefined, long + 1));
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -6204,9 +6842,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                SubRefreshResult.verify = function verify(message) {
+                SubRefreshResult.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.expires != null && message.hasOwnProperty("expires"))
                         if (typeof message.expires !== "boolean")
                             return "expires: boolean expected";
@@ -6217,7 +6859,7 @@ export const centrifugal = $root.centrifugal = (() => {
                         if (!Array.isArray(message.items))
                             return "items: array expected";
                         for (let i = 0; i < message.items.length; ++i) {
-                            let error = $root.centrifugal.centrifuge.protocol.Publication.verify(message.items[i]);
+                            let error = $root.centrifugal.centrifuge.protocol.Publication.verify(message.items[i], long + 1);
                             if (error)
                                 return "items." + error;
                         }
@@ -6263,7 +6905,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function UnsubscribeRequest(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -6316,19 +6958,25 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                UnsubscribeRequest.decode = function decode(reader, length) {
+                UnsubscribeRequest.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.UnsubscribeRequest();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.channel = reader.string();
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -6359,9 +7007,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                UnsubscribeRequest.verify = function verify(message) {
+                UnsubscribeRequest.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.channel != null && message.hasOwnProperty("channel"))
                         if (!$util.isString(message.channel))
                             return "channel: string expected";
@@ -6405,7 +7057,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function UnsubscribeResult(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -6448,15 +7100,21 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                UnsubscribeResult.decode = function decode(reader, length) {
+                UnsubscribeResult.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.UnsubscribeResult();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -6487,9 +7145,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                UnsubscribeResult.verify = function verify(message) {
+                UnsubscribeResult.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     return null;
                 };
 
@@ -6535,7 +7197,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function PublishRequest(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -6628,12 +7290,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                PublishRequest.decode = function decode(reader, length) {
+                PublishRequest.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.PublishRequest();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.channel = reader.string();
@@ -6656,7 +7324,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -6687,9 +7355,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                PublishRequest.verify = function verify(message) {
+                PublishRequest.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.channel != null && message.hasOwnProperty("channel"))
                         if (!$util.isString(message.channel))
                             return "channel: string expected";
@@ -6745,7 +7417,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function PublishResult(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -6788,15 +7460,21 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                PublishResult.decode = function decode(reader, length) {
+                PublishResult.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.PublishResult();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -6827,9 +7505,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                PublishResult.verify = function verify(message) {
+                PublishResult.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     return null;
                 };
 
@@ -6871,7 +7553,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function PresenceRequest(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -6924,19 +7606,25 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                PresenceRequest.decode = function decode(reader, length) {
+                PresenceRequest.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.PresenceRequest();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.channel = reader.string();
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -6967,9 +7655,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                PresenceRequest.verify = function verify(message) {
+                PresenceRequest.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.channel != null && message.hasOwnProperty("channel"))
                         if (!$util.isString(message.channel))
                             return "channel: string expected";
@@ -7015,7 +7707,7 @@ export const centrifugal = $root.centrifugal = (() => {
                     this.presence = {};
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -7071,12 +7763,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                PresenceResult.decode = function decode(reader, length) {
+                PresenceResult.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.PresenceResult(), key, value;
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 if (message.presence === $util.emptyObject)
@@ -7091,18 +7789,20 @@ export const centrifugal = $root.centrifugal = (() => {
                                         key = reader.string();
                                         break;
                                     case 2:
-                                        value = $root.centrifugal.centrifuge.protocol.ClientInfo.decode(reader, reader.uint32());
+                                        value = $root.centrifugal.centrifuge.protocol.ClientInfo.decode(reader, reader.uint32(), undefined, long + 1);
                                         break;
                                     default:
-                                        reader.skipType(tag2 & 7);
+                                        reader.skipType(tag2 & 7, long);
                                         break;
                                     }
                                 }
+                                if (key === "__proto__")
+                                    $util.makeProp(message.presence, key);
                                 message.presence[key] = value;
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -7133,15 +7833,19 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                PresenceResult.verify = function verify(message) {
+                PresenceResult.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.presence != null && message.hasOwnProperty("presence")) {
                         if (!$util.isObject(message.presence))
                             return "presence: object expected";
                         let key = Object.keys(message.presence);
                         for (let i = 0; i < key.length; ++i) {
-                            let error = $root.centrifugal.centrifuge.protocol.ClientInfo.verify(message.presence[key[i]]);
+                            let error = $root.centrifugal.centrifuge.protocol.ClientInfo.verify(message.presence[key[i]], long + 1);
                             if (error)
                                 return "presence." + error;
                         }
@@ -7187,7 +7891,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function PresenceStatsRequest(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -7240,19 +7944,25 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                PresenceStatsRequest.decode = function decode(reader, length) {
+                PresenceStatsRequest.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.PresenceStatsRequest();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.channel = reader.string();
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -7283,9 +7993,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                PresenceStatsRequest.verify = function verify(message) {
+                PresenceStatsRequest.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.channel != null && message.hasOwnProperty("channel"))
                         if (!$util.isString(message.channel))
                             return "channel: string expected";
@@ -7331,7 +8045,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function PresenceStatsResult(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -7394,12 +8108,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                PresenceStatsResult.decode = function decode(reader, length) {
+                PresenceStatsResult.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.PresenceStatsResult();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.num_clients = reader.uint32();
@@ -7410,7 +8130,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -7441,9 +8161,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                PresenceStatsResult.verify = function verify(message) {
+                PresenceStatsResult.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.num_clients != null && message.hasOwnProperty("num_clients"))
                         if (!$util.isInteger(message.num_clients))
                             return "num_clients: integer expected";
@@ -7492,7 +8216,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function StreamPosition(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -7555,12 +8279,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                StreamPosition.decode = function decode(reader, length) {
+                StreamPosition.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.StreamPosition();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.offset = reader.uint64();
@@ -7571,7 +8301,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -7602,9 +8332,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                StreamPosition.verify = function verify(message) {
+                StreamPosition.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.offset != null && message.hasOwnProperty("offset"))
                         if (!$util.isInteger(message.offset) && !(message.offset && $util.isInteger(message.offset.low) && $util.isInteger(message.offset.high)))
                             return "offset: integer|Long expected";
@@ -7655,7 +8389,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function HistoryRequest(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -7738,12 +8472,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                HistoryRequest.decode = function decode(reader, length) {
+                HistoryRequest.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.HistoryRequest();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.channel = reader.string();
@@ -7754,7 +8494,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         case 8: {
-                                message.since = $root.centrifugal.centrifuge.protocol.StreamPosition.decode(reader, reader.uint32());
+                                message.since = $root.centrifugal.centrifuge.protocol.StreamPosition.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         case 9: {
@@ -7762,7 +8502,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -7793,9 +8533,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                HistoryRequest.verify = function verify(message) {
+                HistoryRequest.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.channel != null && message.hasOwnProperty("channel"))
                         if (!$util.isString(message.channel))
                             return "channel: string expected";
@@ -7803,7 +8547,7 @@ export const centrifugal = $root.centrifugal = (() => {
                         if (!$util.isInteger(message.limit))
                             return "limit: integer expected";
                     if (message.since != null && message.hasOwnProperty("since")) {
-                        let error = $root.centrifugal.centrifuge.protocol.StreamPosition.verify(message.since);
+                        let error = $root.centrifugal.centrifuge.protocol.StreamPosition.verify(message.since, long + 1);
                         if (error)
                             return "since." + error;
                     }
@@ -7854,7 +8598,7 @@ export const centrifugal = $root.centrifugal = (() => {
                     this.publications = [];
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -7928,17 +8672,23 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                HistoryResult.decode = function decode(reader, length) {
+                HistoryResult.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.HistoryResult();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 if (!(message.publications && message.publications.length))
                                     message.publications = [];
-                                message.publications.push($root.centrifugal.centrifuge.protocol.Publication.decode(reader, reader.uint32()));
+                                message.publications.push($root.centrifugal.centrifuge.protocol.Publication.decode(reader, reader.uint32(), undefined, long + 1));
                                 break;
                             }
                         case 2: {
@@ -7950,7 +8700,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -7981,14 +8731,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                HistoryResult.verify = function verify(message) {
+                HistoryResult.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.publications != null && message.hasOwnProperty("publications")) {
                         if (!Array.isArray(message.publications))
                             return "publications: array expected";
                         for (let i = 0; i < message.publications.length; ++i) {
-                            let error = $root.centrifugal.centrifuge.protocol.Publication.verify(message.publications[i]);
+                            let error = $root.centrifugal.centrifuge.protocol.Publication.verify(message.publications[i], long + 1);
                             if (error)
                                 return "publications." + error;
                         }
@@ -8039,7 +8793,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function PingRequest(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -8082,15 +8836,21 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                PingRequest.decode = function decode(reader, length) {
+                PingRequest.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.PingRequest();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -8121,9 +8881,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                PingRequest.verify = function verify(message) {
+                PingRequest.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     return null;
                 };
 
@@ -8164,7 +8928,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function PingResult(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -8207,15 +8971,21 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                PingResult.decode = function decode(reader, length) {
+                PingResult.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.PingResult();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -8246,9 +9016,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                PingResult.verify = function verify(message) {
+                PingResult.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     return null;
                 };
 
@@ -8291,7 +9065,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function RPCRequest(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -8354,12 +9128,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                RPCRequest.decode = function decode(reader, length) {
+                RPCRequest.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.RPCRequest();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.data = reader.bytes();
@@ -8370,7 +9150,7 @@ export const centrifugal = $root.centrifugal = (() => {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -8401,9 +9181,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                RPCRequest.verify = function verify(message) {
+                RPCRequest.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.data != null && message.hasOwnProperty("data"))
                         if (!(message.data && typeof message.data.length === "number" || $util.isString(message.data)))
                             return "data: buffer expected";
@@ -8451,7 +9235,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function RPCResult(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -8504,19 +9288,25 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                RPCResult.decode = function decode(reader, length) {
+                RPCResult.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.RPCResult();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.data = reader.bytes();
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -8547,9 +9337,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                RPCResult.verify = function verify(message) {
+                RPCResult.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.data != null && message.hasOwnProperty("data"))
                         if (!(message.data && typeof message.data.length === "number" || $util.isString(message.data)))
                             return "data: buffer expected";
@@ -8594,7 +9388,7 @@ export const centrifugal = $root.centrifugal = (() => {
                 function SendRequest(properties) {
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -8647,19 +9441,25 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                SendRequest.decode = function decode(reader, length) {
+                SendRequest.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.SendRequest();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.data = reader.bytes();
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -8690,9 +9490,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                SendRequest.verify = function verify(message) {
+                SendRequest.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.data != null && message.hasOwnProperty("data"))
                         if (!(message.data && typeof message.data.length === "number" || $util.isString(message.data)))
                             return "data: buffer expected";
@@ -8744,7 +9548,7 @@ export const centrifugal = $root.centrifugal = (() => {
                     this.nodes = [];
                     if (properties)
                         for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
+                            if (properties[keys[i]] != null && keys[i] !== "__proto__")
                                 this[keys[i]] = properties[keys[i]];
                 }
 
@@ -8849,12 +9653,18 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @throws {Error} If the payload is not a reader or valid buffer
                  * @throws {$protobuf.util.ProtocolError} If required fields are missing
                  */
-                FilterNode.decode = function decode(reader, length) {
+                FilterNode.decode = function decode(reader, length, error, long) {
                     if (!(reader instanceof $Reader))
                         reader = $Reader.create(reader);
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $Reader.recursionLimit)
+                        throw Error("maximum nesting depth exceeded");
                     let end = length === undefined ? reader.len : reader.pos + length, message = new $root.centrifugal.centrifuge.protocol.FilterNode();
                     while (reader.pos < end) {
                         let tag = reader.uint32();
+                        if (tag === error)
+                            break;
                         switch (tag >>> 3) {
                         case 1: {
                                 message.op = reader.string();
@@ -8881,11 +9691,11 @@ export const centrifugal = $root.centrifugal = (() => {
                         case 6: {
                                 if (!(message.nodes && message.nodes.length))
                                     message.nodes = [];
-                                message.nodes.push($root.centrifugal.centrifuge.protocol.FilterNode.decode(reader, reader.uint32()));
+                                message.nodes.push($root.centrifugal.centrifuge.protocol.FilterNode.decode(reader, reader.uint32(), undefined, long + 1));
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7);
+                            reader.skipType(tag & 7, long);
                             break;
                         }
                     }
@@ -8916,9 +9726,13 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @param {Object.<string,*>} message Plain object to verify
                  * @returns {string|null} `null` if valid, otherwise the reason why it is not
                  */
-                FilterNode.verify = function verify(message) {
+                FilterNode.verify = function verify(message, long) {
                     if (typeof message !== "object" || message === null)
                         return "object expected";
+                    if (long === undefined)
+                        long = 0;
+                    if (long > $util.recursionLimit)
+                        return "maximum nesting depth exceeded";
                     if (message.op != null && message.hasOwnProperty("op"))
                         if (!$util.isString(message.op))
                             return "op: string expected";
@@ -8942,7 +9756,7 @@ export const centrifugal = $root.centrifugal = (() => {
                         if (!Array.isArray(message.nodes))
                             return "nodes: array expected";
                         for (let i = 0; i < message.nodes.length; ++i) {
-                            let error = $root.centrifugal.centrifuge.protocol.FilterNode.verify(message.nodes[i]);
+                            let error = $root.centrifugal.centrifuge.protocol.FilterNode.verify(message.nodes[i], long + 1);
                             if (error)
                                 return "nodes." + error;
                         }

--- a/src/client_proto.js
+++ b/src/client_proto.js
@@ -1595,7 +1595,7 @@ export const centrifugal = $root.centrifugal = (() => {
                  * Properties of a ConnectionState.
                  * @memberof centrifugal.centrifuge.protocol
                  * @interface IConnectionState
-                 * @property {centrifugal.centrifuge.protocol.IDictionary|null} [dictionary] ConnectionState dictionary
+                 * @property {centrifugal.centrifuge.protocol.IDictionary|null} [dict] ConnectionState dict
                  */
 
                 /**
@@ -1614,12 +1614,12 @@ export const centrifugal = $root.centrifugal = (() => {
                 }
 
                 /**
-                 * ConnectionState dictionary.
-                 * @member {centrifugal.centrifuge.protocol.IDictionary|null|undefined} dictionary
+                 * ConnectionState dict.
+                 * @member {centrifugal.centrifuge.protocol.IDictionary|null|undefined} dict
                  * @memberof centrifugal.centrifuge.protocol.ConnectionState
                  * @instance
                  */
-                ConnectionState.prototype.dictionary = null;
+                ConnectionState.prototype.dict = null;
 
                 /**
                  * Encodes the specified ConnectionState message. Does not implicitly {@link centrifugal.centrifuge.protocol.ConnectionState.verify|verify} messages.
@@ -1633,8 +1633,8 @@ export const centrifugal = $root.centrifugal = (() => {
                 ConnectionState.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.dictionary != null && Object.hasOwnProperty.call(message, "dictionary"))
-                        $root.centrifugal.centrifuge.protocol.Dictionary.encode(message.dictionary, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                    if (message.dict != null && Object.hasOwnProperty.call(message, "dict"))
+                        $root.centrifugal.centrifuge.protocol.Dictionary.encode(message.dict, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
                     return writer;
                 };
 
@@ -1676,7 +1676,7 @@ export const centrifugal = $root.centrifugal = (() => {
                             break;
                         switch (tag >>> 3) {
                         case 1: {
-                                message.dictionary = $root.centrifugal.centrifuge.protocol.Dictionary.decode(reader, reader.uint32(), undefined, long + 1);
+                                message.dict = $root.centrifugal.centrifuge.protocol.Dictionary.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
                         default:
@@ -1718,10 +1718,10 @@ export const centrifugal = $root.centrifugal = (() => {
                         long = 0;
                     if (long > $util.recursionLimit)
                         return "maximum nesting depth exceeded";
-                    if (message.dictionary != null && message.hasOwnProperty("dictionary")) {
-                        let error = $root.centrifugal.centrifuge.protocol.Dictionary.verify(message.dictionary, long + 1);
+                    if (message.dict != null && message.hasOwnProperty("dict")) {
+                        let error = $root.centrifugal.centrifuge.protocol.Dictionary.verify(message.dict, long + 1);
                         if (error)
-                            return "dictionary." + error;
+                            return "dict." + error;
                     }
                     return null;
                 };
@@ -4136,6 +4136,8 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @property {string|null} [version] ConnectRequest version
                  * @property {Object.<string,string>|null} [headers] ConnectRequest headers
                  * @property {number|Long|null} [flag] ConnectRequest flag
+                 * @property {string|null} [profile] ConnectRequest profile
+                 * @property {string|null} [dict] ConnectRequest dict
                  */
 
                 /**
@@ -4212,6 +4214,22 @@ export const centrifugal = $root.centrifugal = (() => {
                 ConnectRequest.prototype.flag = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
                 /**
+                 * ConnectRequest profile.
+                 * @member {string} profile
+                 * @memberof centrifugal.centrifuge.protocol.ConnectRequest
+                 * @instance
+                 */
+                ConnectRequest.prototype.profile = "";
+
+                /**
+                 * ConnectRequest dict.
+                 * @member {string} dict
+                 * @memberof centrifugal.centrifuge.protocol.ConnectRequest
+                 * @instance
+                 */
+                ConnectRequest.prototype.dict = "";
+
+                /**
                  * Encodes the specified ConnectRequest message. Does not implicitly {@link centrifugal.centrifuge.protocol.ConnectRequest.verify|verify} messages.
                  * @function encode
                  * @memberof centrifugal.centrifuge.protocol.ConnectRequest
@@ -4241,6 +4259,10 @@ export const centrifugal = $root.centrifugal = (() => {
                             writer.uint32(/* id 6, wireType 2 =*/50).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.headers[keys[i]]).ldelim();
                     if (message.flag != null && Object.hasOwnProperty.call(message, "flag"))
                         writer.uint32(/* id 7, wireType 0 =*/56).int64(message.flag);
+                    if (message.dict != null && Object.hasOwnProperty.call(message, "dict"))
+                        writer.uint32(/* id 8, wireType 2 =*/66).string(message.dict);
+                    if (message.profile != null && Object.hasOwnProperty.call(message, "profile"))
+                        writer.uint32(/* id 9, wireType 2 =*/74).string(message.profile);
                     return writer;
                 };
 
@@ -4351,6 +4373,14 @@ export const centrifugal = $root.centrifugal = (() => {
                                 message.flag = reader.int64();
                                 break;
                             }
+                        case 9: {
+                                message.profile = reader.string();
+                                break;
+                            }
+                        case 8: {
+                                message.dict = reader.string();
+                                break;
+                            }
                         default:
                             reader.skipType(tag & 7, long);
                             break;
@@ -4423,6 +4453,12 @@ export const centrifugal = $root.centrifugal = (() => {
                     if (message.flag != null && message.hasOwnProperty("flag"))
                         if (!$util.isInteger(message.flag) && !(message.flag && $util.isInteger(message.flag.low) && $util.isInteger(message.flag.high)))
                             return "flag: integer|Long expected";
+                    if (message.profile != null && message.hasOwnProperty("profile"))
+                        if (!$util.isString(message.profile))
+                            return "profile: string expected";
+                    if (message.dict != null && message.hasOwnProperty("dict"))
+                        if (!$util.isString(message.dict))
+                            return "dict: string expected";
                     return null;
                 };
 
@@ -4462,6 +4498,7 @@ export const centrifugal = $root.centrifugal = (() => {
                  * @property {string|null} [node] ConnectResult node
                  * @property {number|Long|null} [time] ConnectResult time
                  * @property {number|Long|null} [flag] ConnectResult flag
+                 * @property {centrifugal.centrifuge.protocol.IDictionary|null} [dict] ConnectResult dict
                  */
 
                 /**
@@ -4577,6 +4614,14 @@ export const centrifugal = $root.centrifugal = (() => {
                 ConnectResult.prototype.flag = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
                 /**
+                 * ConnectResult dict.
+                 * @member {centrifugal.centrifuge.protocol.IDictionary|null|undefined} dict
+                 * @memberof centrifugal.centrifuge.protocol.ConnectResult
+                 * @instance
+                 */
+                ConnectResult.prototype.dict = null;
+
+                /**
                  * Encodes the specified ConnectResult message. Does not implicitly {@link centrifugal.centrifuge.protocol.ConnectResult.verify|verify} messages.
                  * @function encode
                  * @memberof centrifugal.centrifuge.protocol.ConnectResult
@@ -4615,6 +4660,8 @@ export const centrifugal = $root.centrifugal = (() => {
                         writer.uint32(/* id 11, wireType 0 =*/88).int64(message.time);
                     if (message.flag != null && Object.hasOwnProperty.call(message, "flag"))
                         writer.uint32(/* id 12, wireType 0 =*/96).int64(message.flag);
+                    if (message.dict != null && Object.hasOwnProperty.call(message, "dict"))
+                        $root.centrifugal.centrifuge.protocol.Dictionary.encode(message.dict, writer.uint32(/* id 13, wireType 2 =*/106).fork()).ldelim();
                     return writer;
                 };
 
@@ -4724,6 +4771,10 @@ export const centrifugal = $root.centrifugal = (() => {
                                 message.flag = reader.int64();
                                 break;
                             }
+                        case 13: {
+                                message.dict = $root.centrifugal.centrifuge.protocol.Dictionary.decode(reader, reader.uint32(), undefined, long + 1);
+                                break;
+                            }
                         default:
                             reader.skipType(tag & 7, long);
                             break;
@@ -4806,6 +4857,11 @@ export const centrifugal = $root.centrifugal = (() => {
                     if (message.flag != null && message.hasOwnProperty("flag"))
                         if (!$util.isInteger(message.flag) && !(message.flag && $util.isInteger(message.flag.low) && $util.isInteger(message.flag.high)))
                             return "flag: integer|Long expected";
+                    if (message.dict != null && message.hasOwnProperty("dict")) {
+                        let error = $root.centrifugal.centrifuge.protocol.Dictionary.verify(message.dict, long + 1);
+                        if (error)
+                            return "dict." + error;
+                    }
                     return null;
                 };
 

--- a/src/dictionary_cache.test.ts
+++ b/src/dictionary_cache.test.ts
@@ -1,18 +1,21 @@
-import { DictionaryCache } from './dictionary_cache';
+import { DictionaryCache, dictionaryId } from './dictionary_cache';
 
 // The cache is what makes a returning client compress from its first frame
-// instead of carrying kilobytes uncompressed while it earns a dictionary. It
-// also has to fail safe: an entry that cannot be trusted must look absent rather
-// than produce garbage.
+// instead of paying for a dictionary transfer it already has. It also has to
+// fail safe, and "safe" here is stronger than it sounds: bytes substituted in
+// storage make legitimate server frames decode into content of the
+// substituter's choosing, so an entry that cannot be verified against its id
+// must look absent rather than be used.
 describe('dictionary cache', () => {
   const dict = new TextEncoder().encode('{"push":{"channel":"","pub":{"data":{');
+  let realId: string;
 
-  // Node's ambient localStorage is not usable here, and the cache treats that as
-  // "no storage" by design. These tests are about the caching behaviour, so they
-  // install a working one.
   let store: Map<string, string>;
-  beforeEach(() => {
+  beforeEach(async () => {
+    realId = await dictionaryId(dict);
     store = new Map<string, string>();
+    // Node's ambient localStorage is not usable here, and the cache treats that
+    // as "no storage" by design. These tests are about caching, so install one.
     Object.defineProperty(globalThis, 'localStorage', {
       configurable: true,
       value: {
@@ -23,19 +26,36 @@ describe('dictionary cache', () => {
     });
   });
 
-  it('returns bytes only for the id they were stored under', () => {
+  // A cache that has just read storage. Verification is asynchronous because
+  // that is the only digest a browser offers, so anything reading a reloaded
+  // entry has to wait for it.
+  const reloaded = async () => {
     const c = new DictionaryCache();
-    c.put('abc', dict);
-    expect(c.get('abc')).toEqual(dict);
+    await c.warm();
+    return c;
+  };
+
+  it('computes the same id as the server', async () => {
+    // Byte-for-byte identical to DictionaryID in centrifugal/protocol:
+    // base64url of the first 12 bytes of SHA-256, unpadded. A mismatch here
+    // would turn every cache hit into a silent miss.
+    expect(realId).toMatch(/^[A-Za-z0-9_-]{16}$/);
+    expect(await dictionaryId(dict)).toEqual(realId);
+  });
+
+  it('returns bytes only for the id they were stored under', async () => {
+    const c = new DictionaryCache();
+    c.put(realId, dict);
+    expect(c.get(realId)).toEqual(dict);
     expect(c.get('other')).toBeNull();
     expect(c.get('')).toBeNull();
   });
 
-  it('advertises what it holds, and nothing when empty', () => {
+  it('advertises what it holds, and nothing when empty', async () => {
     const c = new DictionaryCache();
     expect(c.advertise()).toEqual('');
-    c.put('abc', dict);
-    expect(c.advertise()).toEqual('abc');
+    c.put(realId, dict);
+    expect(c.advertise()).toEqual(realId);
   });
 
   it('keeps only the latest, since the id changes only on upgrade', () => {
@@ -46,37 +66,79 @@ describe('dictionary cache', () => {
     expect(c.get('v1')).toBeNull();
   });
 
-  it('survives a reload', () => {
-    new DictionaryCache().put('abc', dict);
-    const fresh = new DictionaryCache();
-    expect(fresh.advertise()).toEqual('abc');
-    expect(fresh.get('abc')).toEqual(dict);
+  it('survives a reload', async () => {
+    new DictionaryCache().put(realId, dict);
+    const fresh = await reloaded();
+    expect(fresh.advertise()).toEqual(realId);
+    expect(fresh.get(realId)).toEqual(dict);
   });
 
-  it('forgets an entry, so a bad one is not advertised again', () => {
-    const c = new DictionaryCache();
-    c.put('abc', dict);
-    c.forget('nomatch');
-    expect(c.advertise()).toEqual('abc');
-    c.forget('abc');
-    expect(c.advertise()).toEqual('');
+  it('advertises nothing until verification finishes', () => {
+    new DictionaryCache().put(realId, dict);
+    // Read synchronously, before the digest can have resolved. Empty is the
+    // safe answer: it costs one transfer and never decodes against unverified
+    // bytes.
     expect(new DictionaryCache().advertise()).toEqual('');
   });
 
-  it('rejects storage that was corrupted underneath it', () => {
-    new DictionaryCache().put('abc', dict);
+  it('rejects bytes substituted under a real id', async () => {
+    new DictionaryCache().put(realId, dict);
     const raw = JSON.parse(store.get('centrifuge.dict')!);
-    // Same length, different content: only the checksum can catch this, and
-    // decoding frames against it would corrupt every one of them.
+    // Same length, different content. This is the attack the hash exists for:
+    // a CRC is forgeable, and decoding against these bytes would put the
+    // substituter's content into frames the application trusts.
     raw.b64 = btoa('x'.repeat(dict.length));
     store.set('centrifuge.dict', JSON.stringify(raw));
-    expect(new DictionaryCache().advertise()).toEqual('');
+    const c = await reloaded();
+    expect(c.advertise()).toEqual('');
+    expect(c.get(realId)).toBeNull();
+    expect(store.has('centrifuge.dict')).toBe(false);
   });
 
-  it('ignores unparseable storage', () => {
+  it('does not let a matching forged id become a real one', async () => {
+    // Rewriting bytes *and* id together passes local verification - there is
+    // nothing on the client to say otherwise. It is harmless because the id no
+    // server ever issued is an id no server recognises, so the server sends the
+    // genuine dictionary and these bytes are never used to decode anything.
+    const evil = new TextEncoder().encode('x'.repeat(dict.length));
+    const evilId = await dictionaryId(evil);
+    store.set('centrifuge.dict', JSON.stringify({ id: evilId, b64: btoa('x'.repeat(dict.length)) }));
+    const c = await reloaded();
+    expect(c.advertise()).toEqual(evilId);
+    expect(c.advertise()).not.toEqual(realId);
+  });
+
+  it('forgets an entry, so a bad one is not advertised again', async () => {
+    const c = new DictionaryCache();
+    c.put(realId, dict);
+    c.forget('nomatch');
+    expect(c.advertise()).toEqual(realId);
+    c.forget(realId);
+    expect(c.advertise()).toEqual('');
+    expect((await reloaded()).advertise()).toEqual('');
+  });
+
+  it('does not let a slow digest clobber a fresher dictionary', async () => {
+    // Storage holds an old entry; a connection completes and stores a new one
+    // before verification of the old one finishes. The new one has to win, or a
+    // client would advertise a dictionary the server has already replaced.
+    new DictionaryCache().put(realId, dict);
+    const newer = new TextEncoder().encode('{"push":{"channel":"","pub":{"data":{"v":2}}}}');
+    const newerId = await dictionaryId(newer);
+
+    const c = new DictionaryCache();
+    const verifying = c.warm();
+    c.put(newerId, newer);
+    await verifying;
+
+    expect(c.advertise()).toEqual(newerId);
+    expect(c.get(newerId)).toEqual(newer);
+  });
+
+  it('ignores unparseable storage', async () => {
     store.set('centrifuge.dict', 'not json');
-    expect(new DictionaryCache().advertise()).toEqual('');
+    expect((await reloaded()).advertise()).toEqual('');
     store.set('centrifuge.dict', '{"id":"x"}');
-    expect(new DictionaryCache().advertise()).toEqual('');
+    expect((await reloaded()).advertise()).toEqual('');
   });
 });

--- a/src/dictionary_cache.test.ts
+++ b/src/dictionary_cache.test.ts
@@ -33,23 +33,23 @@ describe('dictionary cache', () => {
 
   it('advertises what it holds, and nothing when empty', () => {
     const c = new DictionaryCache();
-    expect(c.ids()).toEqual([]);
+    expect(c.advertise()).toEqual('');
     c.put('abc', dict);
-    expect(c.ids()).toEqual(['abc']);
+    expect(c.advertise()).toEqual('abc');
   });
 
   it('keeps only the latest, since the id changes only on upgrade', () => {
     const c = new DictionaryCache();
     c.put('v1', dict);
     c.put('v2', dict);
-    expect(c.ids()).toEqual(['v2']);
+    expect(c.advertise()).toEqual('v2');
     expect(c.get('v1')).toBeNull();
   });
 
   it('survives a reload', () => {
     new DictionaryCache().put('abc', dict);
     const fresh = new DictionaryCache();
-    expect(fresh.ids()).toEqual(['abc']);
+    expect(fresh.advertise()).toEqual('abc');
     expect(fresh.get('abc')).toEqual(dict);
   });
 
@@ -57,10 +57,10 @@ describe('dictionary cache', () => {
     const c = new DictionaryCache();
     c.put('abc', dict);
     c.forget('nomatch');
-    expect(c.ids()).toEqual(['abc']);
+    expect(c.advertise()).toEqual('abc');
     c.forget('abc');
-    expect(c.ids()).toEqual([]);
-    expect(new DictionaryCache().ids()).toEqual([]);
+    expect(c.advertise()).toEqual('');
+    expect(new DictionaryCache().advertise()).toEqual('');
   });
 
   it('rejects storage that was corrupted underneath it', () => {
@@ -70,13 +70,13 @@ describe('dictionary cache', () => {
     // decoding frames against it would corrupt every one of them.
     raw.b64 = btoa('x'.repeat(dict.length));
     store.set('centrifuge.dict', JSON.stringify(raw));
-    expect(new DictionaryCache().ids()).toEqual([]);
+    expect(new DictionaryCache().advertise()).toEqual('');
   });
 
   it('ignores unparseable storage', () => {
     store.set('centrifuge.dict', 'not json');
-    expect(new DictionaryCache().ids()).toEqual([]);
+    expect(new DictionaryCache().advertise()).toEqual('');
     store.set('centrifuge.dict', '{"id":"x"}');
-    expect(new DictionaryCache().ids()).toEqual([]);
+    expect(new DictionaryCache().advertise()).toEqual('');
   });
 });

--- a/src/dictionary_cache.test.ts
+++ b/src/dictionary_cache.test.ts
@@ -1,4 +1,25 @@
+import { webcrypto } from 'node:crypto';
 import { DictionaryCache, dictionaryId } from './dictionary_cache';
+
+// Node exposes globalThis.crypto only from v19. CI no longer runs anything
+// older, but a local toolchain might, and without this the cache would correctly
+// decline to persist what it cannot verify - turning every test about
+// verification into a test of the degraded path instead. That path has its own
+// tests at the bottom of this file.
+if (!(globalThis as any).crypto?.subtle) {
+  Object.defineProperty(globalThis, 'crypto', { configurable: true, value: webcrypto });
+}
+
+// Verification is asynchronous and reports completion nowhere, so waiting a
+// fixed tick for it is a race: one macrotask is enough on an idle laptop and not
+// on a loaded CI runner.
+const eventually = async (cond: () => boolean, what: string) => {
+  for (let i = 0; i < 200; i++) {
+    if (cond()) return;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error(`timed out waiting for ${what}`);
+};
 
 // The cache is what makes a returning client compress from its first frame
 // instead of paying for a dictionary transfer it already has. It also has to
@@ -118,8 +139,7 @@ describe('dictionary cache', () => {
     const c = new DictionaryCache();
     c.put('not-the-hash-of-these-bytes', dict);
     expect(c.advertise()).toEqual('not-the-hash-of-these-bytes'); // stored optimistically
-    await new Promise((r) => setTimeout(r, 0)); // let the digest settle
-    expect(c.advertise()).toEqual('');
+    await eventually(() => c.advertise() === '', 'the unverifiable entry to be dropped');
     expect(c.get('not-the-hash-of-these-bytes')).toBeNull();
     expect(store.has('centrifuge.dict')).toBe(false);
     expect((await reloaded()).advertise()).toEqual('');

--- a/src/dictionary_cache.test.ts
+++ b/src/dictionary_cache.test.ts
@@ -199,3 +199,55 @@ describe('dictionary cache', () => {
     expect((await reloaded()).advertise()).toEqual('');
   });
 });
+
+// Degraded environments. Compression must keep working where the cache cannot:
+// an insecure origin has no WebCrypto, React Native has neither it nor
+// localStorage by default, and Node has no localStorage. In all of them a
+// client should still decode every frame and simply pay for the dictionary once
+// per process rather than once per week.
+describe('dictionary cache without platform APIs', () => {
+  const dict = new TextEncoder().encode('{"push":{"channel":"","pub":{"data":{');
+
+  it('caches in memory and writes nothing when WebCrypto is missing', async () => {
+    const store = new Map<string, string>();
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+        setItem: (k: string, v: string) => { store.set(k, v); },
+        removeItem: (k: string) => { store.delete(k); },
+      },
+    });
+    const realCrypto = (globalThis as any).crypto;
+    Object.defineProperty(globalThis, 'crypto', { configurable: true, value: undefined });
+    try {
+      const c = new DictionaryCache();
+      c.put('some-id', dict);
+      // Usable for this session's reconnects: these bytes came from the server
+      // on this connection, so there is nothing to distrust.
+      expect(c.advertise()).toEqual('some-id');
+      expect(c.get('some-id')).toEqual(dict);
+      await new Promise((r) => setTimeout(r, 0));
+      expect(c.advertise()).toEqual('some-id');
+      // But nothing persisted, because nothing could verify it on the way back.
+      expect(store.has('centrifuge.dict')).toBe(false);
+    } finally {
+      Object.defineProperty(globalThis, 'crypto', { configurable: true, value: realCrypto });
+    }
+  });
+
+  it('caches in memory when there is no localStorage at all', async () => {
+    const realStorage = (globalThis as any).localStorage;
+    Object.defineProperty(globalThis, 'localStorage', { configurable: true, value: undefined });
+    try {
+      const c = new DictionaryCache();
+      c.put('some-id', dict);
+      expect(c.get('some-id')).toEqual(dict);
+      expect(c.advertise()).toEqual('some-id');
+      c.forget('some-id');
+      expect(c.advertise()).toEqual('');
+    } finally {
+      Object.defineProperty(globalThis, 'localStorage', { configurable: true, value: realStorage });
+    }
+  });
+});

--- a/src/dictionary_cache.test.ts
+++ b/src/dictionary_cache.test.ts
@@ -109,6 +109,30 @@ describe('dictionary cache', () => {
     expect(c.advertise()).not.toEqual(realId);
   });
 
+  it('does not cache a dictionary whose id does not name its content', async () => {
+    // A server that derives ids differently, or gets its own bookkeeping wrong.
+    // The connection itself is fine - it compresses against the bytes it sent -
+    // but caching this would mean advertising an id, being told to reuse it,
+    // and dropping it again on every single load. Refusing once is the same
+    // outcome without the churn.
+    const c = new DictionaryCache();
+    c.put('not-the-hash-of-these-bytes', dict);
+    expect(c.advertise()).toEqual('not-the-hash-of-these-bytes'); // stored optimistically
+    await new Promise((r) => setTimeout(r, 0)); // let the digest settle
+    expect(c.advertise()).toEqual('');
+    expect(c.get('not-the-hash-of-these-bytes')).toBeNull();
+    expect(store.has('centrifuge.dict')).toBe(false);
+    expect((await reloaded()).advertise()).toEqual('');
+  });
+
+  it('keeps a dictionary whose id does name its content', async () => {
+    const c = new DictionaryCache();
+    c.put(realId, dict);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(c.advertise()).toEqual(realId);
+    expect(c.get(realId)).toEqual(dict);
+  });
+
   it('forgets an entry, so a bad one is not advertised again', async () => {
     const c = new DictionaryCache();
     c.put(realId, dict);

--- a/src/dictionary_cache.test.ts
+++ b/src/dictionary_cache.test.ts
@@ -1,0 +1,82 @@
+import { DictionaryCache } from './dictionary_cache';
+
+// The cache is what makes a returning client compress from its first frame
+// instead of carrying kilobytes uncompressed while it earns a dictionary. It
+// also has to fail safe: an entry that cannot be trusted must look absent rather
+// than produce garbage.
+describe('dictionary cache', () => {
+  const dict = new TextEncoder().encode('{"push":{"channel":"","pub":{"data":{');
+
+  // Node's ambient localStorage is not usable here, and the cache treats that as
+  // "no storage" by design. These tests are about the caching behaviour, so they
+  // install a working one.
+  let store: Map<string, string>;
+  beforeEach(() => {
+    store = new Map<string, string>();
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+        setItem: (k: string, v: string) => { store.set(k, v); },
+        removeItem: (k: string) => { store.delete(k); },
+      },
+    });
+  });
+
+  it('returns bytes only for the id they were stored under', () => {
+    const c = new DictionaryCache();
+    c.put('abc', dict);
+    expect(c.get('abc')).toEqual(dict);
+    expect(c.get('other')).toBeNull();
+    expect(c.get('')).toBeNull();
+  });
+
+  it('advertises what it holds, and nothing when empty', () => {
+    const c = new DictionaryCache();
+    expect(c.ids()).toEqual([]);
+    c.put('abc', dict);
+    expect(c.ids()).toEqual(['abc']);
+  });
+
+  it('keeps only the latest, since the id changes only on upgrade', () => {
+    const c = new DictionaryCache();
+    c.put('v1', dict);
+    c.put('v2', dict);
+    expect(c.ids()).toEqual(['v2']);
+    expect(c.get('v1')).toBeNull();
+  });
+
+  it('survives a reload', () => {
+    new DictionaryCache().put('abc', dict);
+    const fresh = new DictionaryCache();
+    expect(fresh.ids()).toEqual(['abc']);
+    expect(fresh.get('abc')).toEqual(dict);
+  });
+
+  it('forgets an entry, so a bad one is not advertised again', () => {
+    const c = new DictionaryCache();
+    c.put('abc', dict);
+    c.forget('nomatch');
+    expect(c.ids()).toEqual(['abc']);
+    c.forget('abc');
+    expect(c.ids()).toEqual([]);
+    expect(new DictionaryCache().ids()).toEqual([]);
+  });
+
+  it('rejects storage that was corrupted underneath it', () => {
+    new DictionaryCache().put('abc', dict);
+    const raw = JSON.parse(store.get('centrifuge.dict')!);
+    // Same length, different content: only the checksum can catch this, and
+    // decoding frames against it would corrupt every one of them.
+    raw.b64 = btoa('x'.repeat(dict.length));
+    store.set('centrifuge.dict', JSON.stringify(raw));
+    expect(new DictionaryCache().ids()).toEqual([]);
+  });
+
+  it('ignores unparseable storage', () => {
+    store.set('centrifuge.dict', 'not json');
+    expect(new DictionaryCache().ids()).toEqual([]);
+    store.set('centrifuge.dict', '{"id":"x"}');
+    expect(new DictionaryCache().ids()).toEqual([]);
+  });
+});

--- a/src/dictionary_cache.test.ts
+++ b/src/dictionary_cache.test.ts
@@ -102,7 +102,8 @@ describe('dictionary cache', () => {
     // genuine dictionary and these bytes are never used to decode anything.
     const evil = new TextEncoder().encode('x'.repeat(dict.length));
     const evilId = await dictionaryId(evil);
-    store.set('centrifuge.dict', JSON.stringify({ id: evilId, b64: btoa('x'.repeat(dict.length)) }));
+    // Written with a current timestamp so this exercises forgery, not expiry.
+    store.set('centrifuge.dict', JSON.stringify({ id: evilId, b64: btoa('x'.repeat(dict.length)), at: Date.now() }));
     const c = await reloaded();
     expect(c.advertise()).toEqual(evilId);
     expect(c.advertise()).not.toEqual(realId);
@@ -133,6 +134,38 @@ describe('dictionary cache', () => {
 
     expect(c.advertise()).toEqual(newerId);
     expect(c.get(newerId)).toEqual(newer);
+  });
+
+  it('drops an entry older than its lifetime', async () => {
+    // The id is advertised on every connect, so an unbounded cache lets a
+    // stable, server-chosen value follow a client forever. Expiry bounds that
+    // window; it is not a freshness check, since content-addressed ids already
+    // make a stale dictionary harmless.
+    new DictionaryCache().put(realId, dict);
+    const raw = JSON.parse(store.get('centrifuge.dict')!);
+    raw.at = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    store.set('centrifuge.dict', JSON.stringify(raw));
+
+    const c = await reloaded();
+    expect(c.advertise()).toEqual('');
+    expect(store.has('centrifuge.dict')).toBe(false);
+  });
+
+  it('keeps an entry inside its lifetime', async () => {
+    new DictionaryCache().put(realId, dict);
+    const raw = JSON.parse(store.get('centrifuge.dict')!);
+    raw.at = Date.now() - 6 * 24 * 60 * 60 * 1000;
+    store.set('centrifuge.dict', JSON.stringify(raw));
+
+    expect((await reloaded()).advertise()).toEqual(realId);
+  });
+
+  it('drops an entry written before expiry existed', async () => {
+    // No timestamp means it predates this rule, and could be arbitrarily old.
+    // Dropping it costs one transfer; keeping it would exempt exactly the
+    // entries that have already lived longest.
+    store.set('centrifuge.dict', JSON.stringify({ id: realId, b64: btoa('x'.repeat(dict.length)) }));
+    expect((await reloaded()).advertise()).toEqual('');
   });
 
   it('ignores unparseable storage', async () => {

--- a/src/dictionary_cache.ts
+++ b/src/dictionary_cache.ts
@@ -1,0 +1,175 @@
+/**
+ * Where the structure dictionary is kept between connections.
+ * @internal
+ */
+const storageKey = 'centrifuge.dict';
+
+/**
+ * dictionaryCache remembers the structure dictionary across connections, so a
+ * reconnect costs an id rather than a transfer.
+ *
+ * Only the structure dictionary is stored, and only the most recent one. Its id
+ * changes only when a server is upgraded or an operator edits it, so a single
+ * entry matches on essentially every reconnect; during a rolling deploy, where
+ * old and new nodes disagree, a client re-downloads once per hop at about 1.6 KB
+ * and needs no eviction policy to get right.
+ *
+ * Channel dictionaries are deliberately never stored. They contain verbatim
+ * fragments of other users' messages, and writing those to disk on a shared
+ * machine would outlive the session that was entitled to them. They are also
+ * built per node, so a stored copy would rarely match anyway.
+ *
+ * The id is a hash of the content, computed by the server, so an entry can never
+ * be used for a dictionary whose bytes differ. The CRC guards the other
+ * direction - storage that was truncated or edited underneath us - since a
+ * browser cannot recompute the server's hash synchronously.
+ *
+ * @internal
+ */
+export class DictionaryCache {
+  private id: string = '';
+  private dict: Uint8Array | null = null;
+  private loaded: boolean = false;
+
+  /**
+   * Storage is read once, on first use rather than on construction. A page may
+   * create many clients and the entry is per origin, not per client, so reading
+   * it repeatedly would be wasted synchronous I/O on a hot path.
+   */
+  private ensureLoaded(): void {
+    if (this.loaded) {
+      return;
+    }
+    this.loaded = true;
+    this.load();
+  }
+
+  /** Bytes for this id, or null when it is not the one held. */
+  get(id: string): Uint8Array | null {
+    this.ensureLoaded();
+    if (!id || id !== this.id || this.dict === null) {
+      return null;
+    }
+    return this.dict;
+  }
+
+  /** Ids to advertise at connect. The protocol allows several; this keeps one. */
+  ids(): string[] {
+    this.ensureLoaded();
+    return this.id ? [this.id] : [];
+  }
+
+  put(id: string, dict: Uint8Array): void {
+    if (!id || dict.length === 0) {
+      return;
+    }
+    this.ensureLoaded();
+    if (id === this.id) {
+      return; // already stored, no need to write again
+    }
+    this.id = id;
+    this.dict = dict;
+    this.save();
+  }
+
+  /**
+   * Drop the entry. Called when a frame fails to decode while this dictionary is
+   * in use: without it a bad entry would be advertised again on every reconnect
+   * and wedge the client in a loop.
+   */
+  forget(id: string): void {
+    if (id !== this.id) {
+      return;
+    }
+    this.id = '';
+    this.dict = null;
+    try {
+      globalThis.localStorage?.removeItem(storageKey);
+    } catch (e) {
+      // Storage unavailable or blocked - nothing to clean up.
+    }
+  }
+
+  private load(): void {
+    try {
+      const raw = globalThis.localStorage?.getItem(storageKey);
+      if (!raw) {
+        return;
+      }
+      const entry = JSON.parse(raw);
+      if (!entry || typeof entry.id !== 'string' || typeof entry.b64 !== 'string') {
+        return;
+      }
+      const bytes = base64ToBytes(entry.b64);
+      if (bytes.length === 0 || crc32(bytes) !== entry.crc) {
+        // Truncated or tampered with. Decoding against it would corrupt every
+        // frame, so treat it as absent.
+        this.forget(entry.id);
+        return;
+      }
+      this.id = entry.id;
+      this.dict = bytes;
+    } catch (e) {
+      // Unparseable, unavailable, or quota-blocked storage is simply a cache miss.
+    }
+  }
+
+  private save(): void {
+    if (this.dict === null) {
+      return;
+    }
+    try {
+      globalThis.localStorage?.setItem(storageKey, JSON.stringify({
+        id: this.id,
+        b64: bytesToBase64(this.dict),
+        crc: crc32(this.dict),
+      }));
+    } catch (e) {
+      // Storage full or disabled: caching is an optimisation, not a requirement.
+    }
+  }
+}
+
+/**
+ * CRC32 over the stored bytes. This is an integrity check against storage that
+ * was truncated or edited underneath us, not a security measure - a browser
+ * cannot recompute the server's content hash synchronously, and fflate does not
+ * export a checksum, so twelve lines here beat an async digest on a hot path.
+ */
+function crc32(b: Uint8Array): number {
+  let c = ~0;
+  for (let i = 0; i < b.length; i++) {
+    c ^= b[i];
+    for (let k = 0; k < 8; k++) {
+      c = (c >>> 1) ^ (0xedb88320 & -(c & 1));
+    }
+  }
+  return (~c) >>> 0;
+}
+
+function bytesToBase64(b: Uint8Array): string {
+  let s = '';
+  for (let i = 0; i < b.length; i++) {
+    s += String.fromCharCode(b[i]);
+  }
+  return typeof btoa === 'function' ? btoa(s) : Buffer.from(s, 'binary').toString('base64');
+}
+
+function base64ToBytes(s: string): Uint8Array {
+  const binary = typeof atob === 'function'
+    ? atob(s)
+    : Buffer.from(s, 'base64').toString('binary');
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    out[i] = binary.charCodeAt(i);
+  }
+  return out;
+}
+
+/**
+ * The cache shared by every client on this origin. A dictionary is identified by
+ * a hash of its content, so sharing one entry between clients is safe regardless
+ * of which server each is talking to: a mismatched id is simply a miss.
+ * @internal
+ */
+export const sharedDictionaryCache = new DictionaryCache();

--- a/src/dictionary_cache.ts
+++ b/src/dictionary_cache.ts
@@ -4,6 +4,15 @@
  */
 const storageKey = 'centrifuge.dict';
 
+// How long a cached dictionary may live before it is dropped and re-fetched.
+//
+// This bounds a privacy property, not correctness: the id a client advertises
+// is stable and server-chosen, so an unbounded cache lets it follow a client
+// indefinitely. Seven days costs one dictionary transfer per client per week -
+// negligible against what a dictionary saves in that time - while keeping the
+// identifier short-lived enough to be useless for tracking.
+const maxCacheAgeMs = 7 * 24 * 60 * 60 * 1000;
+
 /**
  * dictionaryCache remembers the dictionary the server sent in the connect reply,
  * so a reconnect - including a page reload - costs an id rather than a transfer.
@@ -136,6 +145,18 @@ export class DictionaryCache {
       if (!entry || typeof entry.id !== 'string' || typeof entry.b64 !== 'string') {
         return;
       }
+      // A cached id is advertised on every connect, so it is a stable,
+      // server-chosen value a client hands back indefinitely - which is why
+      // RFC 9842 asks that dictionaries be treated like cookies. Dropping the
+      // entry after a fixed period caps the window in which that id means
+      // anything. It is not a freshness check: content-addressed ids already
+      // make staleness harmless, and an entry with no stored time is from
+      // before this existed and is dropped rather than kept forever.
+      const storedAt = typeof entry.at === 'number' ? entry.at : 0;
+      if (storedAt <= 0 || Date.now() - storedAt > maxCacheAgeMs) {
+        this.remove();
+        return;
+      }
       id = entry.id;
       bytes = base64ToBytes(entry.b64);
     } catch (e) {
@@ -176,6 +197,7 @@ export class DictionaryCache {
       globalThis.localStorage?.setItem(storageKey, JSON.stringify({
         id: this.id,
         b64: bytesToBase64(this.dict),
+        at: Date.now(),
       }));
     } catch (e) {
       // Storage full or disabled: caching is an optimisation, not a requirement.

--- a/src/dictionary_cache.ts
+++ b/src/dictionary_cache.ts
@@ -1,23 +1,24 @@
 /**
- * Where the structure dictionary is kept between connections.
+ * Where the dictionary is kept between connections.
  * @internal
  */
 const storageKey = 'centrifuge.dict';
 
 /**
- * dictionaryCache remembers the structure dictionary across connections, so a
- * reconnect costs an id rather than a transfer.
+ * dictionaryCache remembers the dictionary the server sent in the connect reply,
+ * so a reconnect - including a page reload - costs an id rather than a transfer.
  *
- * Only the structure dictionary is stored, and only the most recent one. Its id
- * changes only when a server is upgraded or an operator edits it, so a single
- * entry matches on essentially every reconnect; during a rolling deploy, where
- * old and new nodes disagree, a client re-downloads once per hop at about 1.6 KB
- * and needs no eviction policy to get right.
+ * One entry, the most recent. A dictionary belongs to a profile and changes only
+ * when the server publishes a new version, so a single entry matches on
+ * essentially every reconnect; during a rolling deploy, where old and new nodes
+ * disagree, a client re-downloads once per hop and needs no eviction policy to
+ * get right. A client that moves between profiles pays one transfer per switch.
  *
- * Channel dictionaries are deliberately never stored. They contain verbatim
- * fragments of other users' messages, and writing those to disk on a shared
- * machine would outlive the session that was entitled to them. They are also
- * built per node, so a stored copy would rarely match anyway.
+ * The entry outlives the session, which is the point - and worth being explicit
+ * about, because a dictionary is a sample of the traffic the profile carries. A
+ * server that puts application content into one is asserting that content may be
+ * handed to any connection of that profile; storing it here extends that to
+ * anyone using the same browser profile afterwards.
  *
  * The id is a hash of the content, computed by the server, so an entry can never
  * be used for a dictionary whose bytes differ. The CRC guards the other
@@ -53,10 +54,10 @@ export class DictionaryCache {
     return this.dict;
   }
 
-  /** Ids to advertise at connect. The protocol allows several; this keeps one. */
-  ids(): string[] {
+  /** The id to advertise at connect, or empty if nothing is cached. */
+  advertise(): string {
     this.ensureLoaded();
-    return this.id ? [this.id] : [];
+    return this.id;
   }
 
   put(id: string, dict: Uint8Array): void {

--- a/src/dictionary_cache.ts
+++ b/src/dictionary_cache.ts
@@ -109,6 +109,38 @@ export class DictionaryCache {
     this.id = id;
     this.dict = dict;
     this.save();
+    // Check that the id a server sent actually names the bytes it sent with it.
+    //
+    // Not for safety - these arrived on the same connection as the frames they
+    // decode, and the server will compress against exactly these bytes, so this
+    // connection is fine either way and is deliberately not interrupted.
+    //
+    // It is to stop a server that derives ids differently from costing every
+    // client its cache in silence. Without this the entry is stored, fails
+    // verification on the next load, is dropped, and re-downloaded - once per
+    // session, forever, with nothing to indicate why. Refusing to cache it says
+    // the same thing in one place instead.
+    void this.verifyOffered(id, dict);
+  }
+
+  /**
+   * Drop a just-stored entry whose id does not match its content. Runs after
+   * put returns, because the only digest a browser offers is asynchronous.
+   */
+  private async verifyOffered(id: string, dict: Uint8Array): Promise<void> {
+    let digest: string;
+    try {
+      digest = await dictionaryId(dict);
+    } catch (e) {
+      return; // No WebCrypto: nothing to check with, and nothing was claimed.
+    }
+    if (digest === id || this.id !== id) {
+      // Matches, or a newer dictionary replaced this one while hashing.
+      return;
+    }
+    this.id = '';
+    this.dict = null;
+    this.remove();
   }
 
   /**

--- a/src/dictionary_cache.ts
+++ b/src/dictionary_cache.ts
@@ -50,6 +50,22 @@ const maxCacheAgeMs = 7 * 24 * 60 * 60 * 1000;
  *
  * @internal
  */
+/**
+ * Whether stored bytes can be checked against their id when they are read back.
+ *
+ * Persisting is only worth doing if they can. Where WebCrypto is missing - an
+ * insecure origin, an older browser, React Native without a polyfill - the cache
+ * stays in memory: reconnects within this page still cost an id rather than a
+ * transfer, and nothing is written that the next load would only discard.
+ *
+ * Compression itself does not depend on any of this. A client with no storage
+ * and no WebCrypto still decodes every frame; it just pays for the dictionary
+ * once per page instead of once per week.
+ */
+function canVerify(): boolean {
+  return typeof (globalThis as any).crypto?.subtle?.digest === 'function';
+}
+
 export class DictionaryCache {
   private id: string = '';
   private dict: Uint8Array | null = null;
@@ -166,6 +182,9 @@ export class DictionaryCache {
   }
 
   private async load(): Promise<void> {
+    if (!canVerify()) {
+      return;
+    }
     let id = '';
     let bytes: Uint8Array | null = null;
     try {
@@ -222,7 +241,7 @@ export class DictionaryCache {
   }
 
   private save(): void {
-    if (this.dict === null) {
+    if (this.dict === null || !canVerify()) {
       return;
     }
     try {

--- a/src/dictionary_cache.ts
+++ b/src/dictionary_cache.ts
@@ -20,43 +20,72 @@ const storageKey = 'centrifuge.dict';
  * handed to any connection of that profile; storing it here extends that to
  * anyone using the same browser profile afterwards.
  *
- * The id is a hash of the content, computed by the server, so an entry can never
- * be used for a dictionary whose bytes differ. The CRC guards the other
- * direction - storage that was truncated or edited underneath us - since a
- * browser cannot recompute the server's hash synchronously.
+ * **Stored bytes are verified against their id before use, by hashing them.**
+ * That is not an integrity check, it is the security boundary of the cache. An
+ * id is the server's hash of the content, and DEFLATE back references resolve
+ * into the dictionary - so bytes substituted in storage do not merely corrupt a
+ * frame, they make a legitimate server frame decode into content of the
+ * substituter's choosing, which the application then handles as a publication.
+ * That is a data-injection primitive, and a checksum does not stop it: a CRC is
+ * trivial to forge.
+ *
+ * Recomputing the hash closes it in both directions. Bytes changed under a real
+ * id fail the comparison and are dropped. Bytes changed together with a matching
+ * forged id verify locally, but then this client advertises an id no server
+ * knows, so the server sends the genuine dictionary and the forged one is never
+ * used.
+ *
+ * Verification is asynchronous, because that is the only digest a browser
+ * offers. It is started once, eagerly, and a client that connects before it
+ * finishes simply advertises nothing and pays one transfer.
  *
  * @internal
  */
 export class DictionaryCache {
   private id: string = '';
   private dict: Uint8Array | null = null;
-  private loaded: boolean = false;
+  private started: boolean = false;
+  /** Resolves when the stored entry has been verified, or found absent. */
+  private ready: Promise<void> | null = null;
 
   /**
    * Storage is read once, on first use rather than on construction. A page may
    * create many clients and the entry is per origin, not per client, so reading
-   * it repeatedly would be wasted synchronous I/O on a hot path.
+   * it repeatedly would be wasted work on a hot path.
    */
-  private ensureLoaded(): void {
-    if (this.loaded) {
-      return;
+  private ensureStarted(): Promise<void> {
+    if (!this.started) {
+      this.started = true;
+      this.ready = this.load();
     }
-    this.loaded = true;
-    this.load();
+    return this.ready as Promise<void>;
   }
 
-  /** Bytes for this id, or null when it is not the one held. */
+  /**
+   * Begin verifying the stored entry. Call as early as possible - the sooner it
+   * finishes the sooner a returning client stops paying for transfers it does
+   * not need.
+   */
+  warm(): Promise<void> {
+    return this.ensureStarted();
+  }
+
+  /** Bytes for this id, or null when it is not the one held and verified. */
   get(id: string): Uint8Array | null {
-    this.ensureLoaded();
+    this.ensureStarted();
     if (!id || id !== this.id || this.dict === null) {
       return null;
     }
     return this.dict;
   }
 
-  /** The id to advertise at connect, or empty if nothing is cached. */
+  /**
+   * The id to advertise at connect, or empty when nothing is cached or
+   * verification has not finished yet. Empty is always safe: it costs one
+   * dictionary transfer and never risks decoding against unverified bytes.
+   */
   advertise(): string {
-    this.ensureLoaded();
+    this.ensureStarted();
     return this.id;
   }
 
@@ -64,7 +93,7 @@ export class DictionaryCache {
     if (!id || dict.length === 0) {
       return;
     }
-    this.ensureLoaded();
+    this.ensureStarted();
     if (id === this.id) {
       return; // already stored, no need to write again
     }
@@ -84,6 +113,10 @@ export class DictionaryCache {
     }
     this.id = '';
     this.dict = null;
+    this.remove();
+  }
+
+  private remove(): void {
     try {
       globalThis.localStorage?.removeItem(storageKey);
     } catch (e) {
@@ -91,7 +124,9 @@ export class DictionaryCache {
     }
   }
 
-  private load(): void {
+  private async load(): Promise<void> {
+    let id = '';
+    let bytes: Uint8Array | null = null;
     try {
       const raw = globalThis.localStorage?.getItem(storageKey);
       if (!raw) {
@@ -101,18 +136,36 @@ export class DictionaryCache {
       if (!entry || typeof entry.id !== 'string' || typeof entry.b64 !== 'string') {
         return;
       }
-      const bytes = base64ToBytes(entry.b64);
-      if (bytes.length === 0 || crc32(bytes) !== entry.crc) {
-        // Truncated or tampered with. Decoding against it would corrupt every
-        // frame, so treat it as absent.
-        this.forget(entry.id);
-        return;
-      }
-      this.id = entry.id;
-      this.dict = bytes;
+      id = entry.id;
+      bytes = base64ToBytes(entry.b64);
     } catch (e) {
       // Unparseable, unavailable, or quota-blocked storage is simply a cache miss.
+      return;
     }
+    if (bytes === null || bytes.length === 0) {
+      this.remove();
+      return;
+    }
+    let digest: string;
+    try {
+      digest = await dictionaryId(bytes);
+    } catch (e) {
+      // No WebCrypto, or it refused. Unverifiable bytes are unusable bytes.
+      this.remove();
+      return;
+    }
+    if (digest !== id) {
+      this.remove();
+      return;
+    }
+    if (this.dict !== null) {
+      // A connection completed while the digest was in flight and stored a
+      // fresher dictionary. What was on disk is stale by definition, so let the
+      // newer one stand rather than clobbering it with what we just verified.
+      return;
+    }
+    this.id = id;
+    this.dict = bytes;
   }
 
   private save(): void {
@@ -123,7 +176,6 @@ export class DictionaryCache {
       globalThis.localStorage?.setItem(storageKey, JSON.stringify({
         id: this.id,
         b64: bytesToBase64(this.dict),
-        crc: crc32(this.dict),
       }));
     } catch (e) {
       // Storage full or disabled: caching is an optimisation, not a requirement.
@@ -132,20 +184,27 @@ export class DictionaryCache {
 }
 
 /**
- * CRC32 over the stored bytes. This is an integrity check against storage that
- * was truncated or edited underneath us, not a security measure - a browser
- * cannot recompute the server's content hash synchronously, and fflate does not
- * export a checksum, so twelve lines here beat an async digest on a hot path.
+ * Recompute the server's dictionary id: the first 12 bytes of SHA-256 over the
+ * content, base64url encoded without padding. Must stay byte-for-byte identical
+ * to DictionaryID in centrifugal/protocol, since a mismatch would silently turn
+ * every cache hit into a miss.
+ *
+ * @internal
  */
-function crc32(b: Uint8Array): number {
-  let c = ~0;
-  for (let i = 0; i < b.length; i++) {
-    c ^= b[i];
-    for (let k = 0; k < 8; k++) {
-      c = (c >>> 1) ^ (0xedb88320 & -(c & 1));
-    }
+export async function dictionaryId(dict: Uint8Array): Promise<string> {
+  const subtle = (globalThis as any).crypto?.subtle;
+  if (!subtle) {
+    throw new Error('centrifuge: no WebCrypto available');
   }
-  return (~c) >>> 0;
+  // Copy into a plain ArrayBuffer: a Uint8Array view over a larger buffer would
+  // otherwise hash the whole buffer.
+  const buf = new Uint8Array(dict).buffer;
+  const sum = new Uint8Array(await subtle.digest('SHA-256', buf));
+  return base64UrlNoPad(sum.subarray(0, 12));
+}
+
+function base64UrlNoPad(b: Uint8Array): string {
+  return bytesToBase64(b).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
 function bytesToBase64(b: Uint8Array): string {
@@ -171,6 +230,10 @@ function base64ToBytes(s: string): Uint8Array {
  * The cache shared by every client on this origin. A dictionary is identified by
  * a hash of its content, so sharing one entry between clients is safe regardless
  * of which server each is talking to: a mismatched id is simply a miss.
+ *
+ * Verification starts here, at module load, so it is almost always finished by
+ * the time anything connects.
  * @internal
  */
 export const sharedDictionaryCache = new DictionaryCache();
+void sharedDictionaryCache.warm();

--- a/src/frame_codec.test.ts
+++ b/src/frame_codec.test.ts
@@ -1,0 +1,146 @@
+import { deflateRawSync } from 'node:zlib';
+import { FrameCodec, frameCodecFromDictionary, FrameCodecRaw, FrameCodecCompressed } from './frame_codec';
+import { DictionaryCache } from './dictionary_cache';
+
+// frame_codec is what every compressed frame passes through, so these cover the
+// two things a wrong answer costs: a frame decoded against the wrong bytes is
+// not an error, it is silently different content, and a frame trusted for its
+// size can be a small input that expands into a large allocation.
+describe('frame codec', () => {
+  const dict = new TextEncoder().encode('{"push":{"channel":"demo","pub":{"data":{"event":"price.changed"');
+  const payload = '{"push":{"channel":"demo","pub":{"data":{"event":"price.changed","v":1}}}}';
+
+  // What a server puts on the wire: a marker byte, then raw DEFLATE against the
+  // shared dictionary.
+  const compressedFrame = (text: string, against: Uint8Array = dict) =>
+    new Uint8Array([FrameCodecCompressed, ...deflateRawSync(Buffer.from(text), { dictionary: Buffer.from(against) })]);
+  const rawFrame = (text: string) =>
+    new Uint8Array([FrameCodecRaw, ...new TextEncoder().encode(text)]);
+
+  it('decodes a frame compressed against its dictionary', () => {
+    const c = new FrameCodec('id', dict);
+    expect(c.decode(compressedFrame(payload), true)).toEqual(payload);
+  });
+
+  it('passes a raw frame through untouched', () => {
+    // The server declines to compress whatever would not shrink, so every
+    // client has to read this marker even on a compressed connection.
+    const c = new FrameCodec('id', dict);
+    expect(c.decode(rawFrame(payload), true)).toEqual(payload);
+  });
+
+  it('returns bytes rather than text on a binary connection', () => {
+    const c = new FrameCodec('id', dict);
+    const out = c.decode(compressedFrame(payload), false);
+    expect(out).toBeInstanceOf(Uint8Array);
+    expect(new TextDecoder().decode(out)).toEqual(payload);
+  });
+
+  it('refuses a marker it does not know', () => {
+    const c = new FrameCodec('id', dict);
+    expect(() => c.decode(new Uint8Array([0x7f, 1, 2, 3]), true)).toThrow(/unknown frame codec/);
+  });
+
+  it('refuses an empty frame', () => {
+    const c = new FrameCodec('id', dict);
+    expect(() => c.decode(new Uint8Array([]), true)).toThrow(/empty frame/);
+  });
+
+  it('does not reproduce the payload when the dictionary differs', () => {
+    // Compressed against the real dictionary, decoded against other bytes. The
+    // frame has to reference the dictionary for this to diverge at all - a
+    // payload with nothing in common with it compresses to literals alone and
+    // decodes identically whatever dictionary is installed, which is the same
+    // property that makes a substituted dictionary able to rewrite content:
+    // what changes is whatever the back references point at.
+    const other = new TextEncoder().encode('unrelated bytes entirely, nothing in common at all');
+    const c = new FrameCodec('id', other);
+    let out: any;
+    try {
+      out = c.decode(compressedFrame(payload, dict), true);
+    } catch (e) {
+      return; // rejected outright, which is the good case
+    }
+    expect(out).not.toEqual(payload);
+  });
+
+  it('refuses a frame that expands past the limit', () => {
+    // A few kilobytes of zeros expand to more than the ceiling. Nothing legitimate
+    // reaches it, so the only sender that gets here is one trying to make the
+    // client allocate on command.
+    const bomb = new Uint8Array([FrameCodecCompressed,
+      ...deflateRawSync(Buffer.alloc(17 * 1024 * 1024), { dictionary: Buffer.from(dict) })]);
+    const c = new FrameCodec('id', dict);
+    expect(() => c.decode(bomb, true)).toThrow(/too large/);
+  });
+
+  it('counts what it received and what it expanded to', () => {
+    const c = new FrameCodec('id', dict);
+    const frame = compressedFrame(payload);
+    c.decode(frame, true);
+    const s = c.getStats();
+    expect(s.frames).toEqual(1);
+    expect(s.bytesReceived).toEqual(frame.length);
+    expect(s.bytesDecompressed).toEqual(payload.length);
+    expect(s.bytesDecompressed).toBeGreaterThan(s.bytesReceived); // it did compress
+  });
+});
+
+describe('building a codec from a connect reply dictionary', () => {
+  // Repetitive, like a real dictionary built from sampled traffic - a few dozen
+  // bytes would not compress, which would make the size assertions vacuous.
+  const dict = new TextEncoder().encode(
+    '{"push":{"channel":"demo","pub":{"data":{"event":"price.changed","symbol":"","venue":"NASDAQ"'.repeat(20));
+  const packed = new Uint8Array(deflateRawSync(Buffer.from(dict)));
+
+  it('takes raw bytes, as a Protobuf connection carries them', () => {
+    const c = frameCodecFromDictionary({ id: 'abc', data: packed });
+    expect(c).not.toBeNull();
+    expect(c!.id).toEqual('abc');
+    expect(c!.dictionary).toEqual(dict);
+  });
+
+  it('takes base64, as a JSON connection carries them', () => {
+    // A bytes field holds raw JSON on a JSON connection, so it cannot hold
+    // binary - the same dictionary arrives base64 encoded instead.
+    const b64 = Buffer.from(packed).toString('base64');
+    const c = frameCodecFromDictionary({ id: 'abc', data_b64: b64 });
+    expect(c).not.toBeNull();
+    expect(c!.dictionary).toEqual(dict);
+  });
+
+  it('charges the dictionary at its encoded size, not its inflated one', () => {
+    const b64 = Buffer.from(packed).toString('base64');
+    const c = frameCodecFromDictionary({ id: 'abc', data_b64: b64 });
+    expect(c!.getStats().dictionaryBytes).toEqual(b64.length);
+    expect(c!.getStats().dictionaryBytes).toBeLessThan(dict.length);
+  });
+
+  it('resolves an id with no content from the cache', () => {
+    // The warm path: the server recognised the id this client advertised, so it
+    // sent nothing and the bytes come from here.
+    const cache = new DictionaryCache();
+    cache.put('abc', dict);
+    const c = frameCodecFromDictionary({ id: 'abc' }, cache);
+    expect(c).not.toBeNull();
+    expect(c!.dictionary).toEqual(dict);
+    // Nothing crossed the wire, so nothing is charged for it.
+    expect(c!.getStats().dictionaryBytes).toEqual(0);
+  });
+
+  it('returns null for an id the client does not hold', () => {
+    // Nothing after this frame could be decoded, so the caller has to notice
+    // rather than install a codec built on nothing.
+    expect(frameCodecFromDictionary({ id: 'unknown' }, new DictionaryCache())).toBeNull();
+    expect(frameCodecFromDictionary({ id: 'unknown' })).toBeNull();
+  });
+
+  it('returns null for content that is not valid deflate', () => {
+    expect(frameCodecFromDictionary({ id: 'abc', data: new Uint8Array([1, 2, 3, 4]) })).toBeNull();
+  });
+
+  it('returns null for nothing at all', () => {
+    expect(frameCodecFromDictionary(null)).toBeNull();
+    expect(frameCodecFromDictionary(undefined)).toBeNull();
+  });
+});

--- a/src/frame_codec.ts
+++ b/src/frame_codec.ts
@@ -1,0 +1,226 @@
+import { inflateSync } from 'fflate';
+import { DictionaryCache } from './dictionary_cache';
+
+/**
+ * ConnectRequest.flag advertises which connection-level capabilities this client
+ * supports. The server replies with the subset it enabled in ConnectResult.flag.
+ * @internal
+ */
+export const connectionFlagDictionaryCompression = 1 << 0;
+
+/**
+ * What this SDK advertises at connect.
+ * @internal
+ */
+export const supportedConnectionFlags = connectionFlagDictionaryCompression;
+
+/**
+ * Frame codec markers. Once a connection has negotiated dictionary compression
+ * every frame starts with one of these.
+ *
+ * The marker deliberately does not name a codec. Which codec a connection uses
+ * is settled once, at connect, by the capability flags the client advertised, so
+ * repeating it per frame would be redundant. The marker only answers the one
+ * question that varies frame to frame: was this frame compressed at all.
+ *
+ * @internal
+ */
+export const FrameCodecRaw = 0x00;
+/** @internal */
+export const FrameCodecCompressed = 0x01;
+
+/**
+ * Bounds a frame after decompression, so a small crafted frame can not be
+ * inflated into an unbounded allocation.
+ * @internal
+ */
+const maxDecompressedFrameSize = 16 * 1024 * 1024;
+
+/**
+ * Bounds a dictionary after inflation, for the same reason. Useful dictionaries
+ * are a few kilobytes; this leaves generous headroom.
+ * @internal
+ */
+const maxDictionarySize = 1024 * 1024;
+
+/**
+ * Dictionary.flags bit 0: content is raw DEFLATE and must be inflated with no
+ * preset dictionary before use.
+ * @internal
+ */
+export const dictionaryFlagDeflate = 1 << 0;
+
+/**
+ * What a connection measured about dictionary compression.
+ * @internal
+ */
+export interface FrameCodecStats {
+  frames: number;
+  bytesReceived: number;
+  bytesDecompressed: number;
+  dictionaryBytes: number;
+}
+
+/**
+ * FrameCodec decodes frames compressed with DEFLATE against a shared dictionary
+ * the server sent over ConnectionState.
+ *
+ * @internal
+ */
+export class FrameCodec {
+  readonly id: string;
+  readonly dictionary: Uint8Array;
+  private dict: Uint8Array;
+  private stats: FrameCodecStats;
+
+  /**
+   * transferred is what the dictionary cost to receive. The built-in dictionary
+   * is compiled in and passes 0, so savings are not charged for bytes that never
+   * crossed the wire.
+   */
+  constructor(id: string, dict: Uint8Array, transferred: number = dict.length) {
+    this.id = id;
+    this.dict = dict;
+    this.dictionary = dict;
+    this.stats = {
+      frames: 0,
+      bytesReceived: 0,
+      bytesDecompressed: 0,
+      dictionaryBytes: transferred,
+    };
+  }
+
+  getStats(): FrameCodecStats {
+    return { ...this.stats };
+  }
+
+  /**
+   * Decode one frame. Input is whatever the transport delivered: an ArrayBuffer
+   * or Uint8Array once compression is active, since compressed payloads arrive
+   * as binary messages even on a JSON connection.
+   *
+   * Returns a string for the JSON protocol and a Uint8Array for Protobuf, which
+   * is what each codec's decodeReplies expects.
+   */
+  decode(data: any, isJson: boolean): any {
+    const bytes = toBytes(data);
+    if (bytes.length === 0) {
+      throw new Error('centrifuge: empty frame');
+    }
+    const marker = bytes[0];
+    const body = bytes.subarray(1);
+
+    let out: Uint8Array;
+    if (marker === FrameCodecRaw) {
+      out = body;
+    } else if (marker === FrameCodecCompressed) {
+      out = inflateSync(body, { dictionary: this.dict, out: undefined });
+      if (out.length > maxDecompressedFrameSize) {
+        throw new Error('centrifuge: decompressed frame too large');
+      }
+    } else {
+      // A marker this client does not know means the server used a codec that
+      // was never negotiated. Guessing would corrupt the stream.
+      throw new Error('centrifuge: unknown frame codec ' + marker);
+    }
+
+    this.stats.frames++;
+    this.stats.bytesReceived += bytes.length;
+    this.stats.bytesDecompressed += out.length;
+
+    return isJson ? new TextDecoder().decode(out) : out;
+  }
+}
+
+function toBytes(data: any): Uint8Array {
+  if (data instanceof Uint8Array) {
+    return data;
+  }
+  if (data instanceof ArrayBuffer) {
+    return new Uint8Array(data);
+  }
+  // A string can only appear here if the server sent a text frame after
+  // activating compression, which it never does.
+  if (typeof data === 'string') {
+    return new TextEncoder().encode(data);
+  }
+  return new Uint8Array(data);
+}
+
+/**
+ * Build a codec from a ConnectionState dictionary payload, or null when the
+ * update carries something this client does not understand.
+ *
+ * Protobuf connections carry the dictionary as raw bytes; JSON connections have
+ * to base64 it, because a bytes field carries raw JSON in that protocol.
+ *
+ * @internal
+ */
+export function frameCodecFromDictionary(dictionary: any, cache?: DictionaryCache): FrameCodec | null {
+  if (!dictionary) {
+    return null;
+  }
+  let raw: Uint8Array | null = null;
+  if (dictionary.data && dictionary.data.length > 0) {
+    raw = toBytes(dictionary.data);
+  } else if (dictionary.data_b64 || dictionary.dataB64) {
+    raw = base64ToBytes(dictionary.data_b64 || dictionary.dataB64);
+  }
+  const id = dictionary.id || '';
+  const flags = Number(dictionary.flags || 0);
+  if (raw !== null && (flags & dictionaryFlagDeflate) !== 0) {
+    // The first dictionary of a connection travels deflated: its delivery frame
+    // could not be compressed, because nothing was installed yet to compress it
+    // against.
+    try {
+      raw = inflateSync(raw);
+    } catch (e) {
+      return null;
+    }
+    if (raw.length > maxDictionarySize) {
+      return null;
+    }
+  }
+  if (!raw || raw.length === 0) {
+    // An id with no content means "use the one you already have": the server
+    // recognised an id this client advertised at connect, so there was nothing
+    // to send. An id is a hash of the content, so a match is byte identical.
+    const held = cache ? cache.get(id) : null;
+    if (held === null) {
+      return null;
+    }
+    // Cached, so it crossed no wire on this connection and is not charged.
+    return new FrameCodec(id, held, 0);
+  }
+  return new FrameCodec(id, raw);
+}
+
+function base64ToBytes(s: string): Uint8Array {
+  const binary = typeof atob === 'function'
+    ? atob(s)
+    // NodeJS has no atob in older versions; Buffer is available there instead.
+    : Buffer.from(s, 'base64').toString('binary');
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    out[i] = binary.charCodeAt(i);
+  }
+  return out;
+}
+
+/**
+ * Byte length of whatever the transport delivered, before decompression.
+ * @internal
+ */
+export function frameByteLength(data: any): number {
+  if (typeof data === 'string') {
+    // A UTF-8 JSON frame: count encoded bytes, not UTF-16 code units.
+    return new TextEncoder().encode(data).length;
+  }
+  if (data instanceof ArrayBuffer) {
+    return data.byteLength;
+  }
+  if (data && typeof data.length === 'number') {
+    return data.length;
+  }
+  return 0;
+}

--- a/src/frame_codec.ts
+++ b/src/frame_codec.ts
@@ -109,10 +109,19 @@ export class FrameCodec {
     if (marker === FrameCodecRaw) {
       out = body;
     } else if (marker === FrameCodecCompressed) {
-      out = inflateSync(body, { dictionary: this.dict, out: undefined });
-      if (out.length > maxDecompressedFrameSize) {
+      // Bounded during inflate, not after: letting it grow first means a
+      // small crafted frame can force the allocation before anything checks
+      // it. One byte over the limit is enough to detect the overflow, because
+      // fflate fills a provided buffer and reports the real length when the
+      // data fits - so a result at capacity means there was more to come.
+      const out2 = inflateSync(body, {
+        dictionary: this.dict,
+        out: new Uint8Array(maxDecompressedFrameSize + 1),
+      });
+      if (out2.length > maxDecompressedFrameSize) {
         throw new Error('centrifuge: decompressed frame too large');
       }
+      out = out2;
     } else {
       // A marker this client does not know means the server used a codec that
       // was never negotiated. Guessing would corrupt the stream.
@@ -166,7 +175,8 @@ export function frameCodecFromDictionary(dictionary: any, cache?: DictionaryCach
     // Content is always deflated: the frame carrying it cannot be compressed,
     // because nothing is installed yet to compress it against.
     try {
-      raw = inflateSync(raw);
+      // Same bound-during-inflate reasoning as decode above.
+      raw = inflateSync(raw, { out: new Uint8Array(maxDictionarySize + 1) });
     } catch (e) {
       return null;
     }

--- a/src/frame_codec.ts
+++ b/src/frame_codec.ts
@@ -165,12 +165,19 @@ export function frameCodecFromDictionary(dictionary: any, cache?: DictionaryCach
     return null;
   }
   let raw: Uint8Array | null = null;
+  let b64: string | null = null;
   if (dictionary.data && dictionary.data.length > 0) {
     raw = toBytes(dictionary.data);
   } else if (dictionary.data_b64 || dictionary.dataB64) {
-    raw = base64ToBytes(dictionary.data_b64 || dictionary.dataB64);
+    b64 = (dictionary.data_b64 || dictionary.dataB64) as string;
+    raw = base64ToBytes(b64);
   }
   const id = dictionary.id || '';
+  // Measured before inflating, on the encoded form, because that is what
+  // actually crossed the wire - deflated, and base64 on top of that for JSON.
+  // Charging the inflated size overstated the cost of the structure dictionary
+  // by most of its size.
+  const wireBytes = b64 !== null ? b64.length : raw !== null ? raw.length : 0;
   if (raw !== null) {
     // Content is always deflated: the frame carrying it cannot be compressed,
     // because nothing is installed yet to compress it against.
@@ -195,7 +202,7 @@ export function frameCodecFromDictionary(dictionary: any, cache?: DictionaryCach
     // Cached, so it crossed no wire on this connection and is not charged.
     return new FrameCodec(id, held, 0);
   }
-  return new FrameCodec(id, raw);
+  return new FrameCodec(id, raw, wireBytes);
 }
 
 function base64ToBytes(s: string): Uint8Array {

--- a/src/frame_codec.ts
+++ b/src/frame_codec.ts
@@ -58,7 +58,7 @@ export interface FrameCodecStats {
 
 /**
  * FrameCodec decodes frames compressed with DEFLATE against a shared dictionary
- * the server sent over ConnectionState.
+ * the server sent in the connect reply.
  *
  * @internal
  */
@@ -152,8 +152,8 @@ function toBytes(data: any): Uint8Array {
 }
 
 /**
- * Build a codec from a ConnectionState dictionary payload, or null when the
- * update carries something this client does not understand.
+ * Build a codec from a connect reply dictionary payload, or null when it
+ * carries something this client does not understand.
  *
  * Protobuf connections carry the dictionary as raw bytes; JSON connections have
  * to base64 it, because a bytes field carries raw JSON in that protocol.

--- a/src/frame_codec.ts
+++ b/src/frame_codec.ts
@@ -62,6 +62,11 @@ export interface FrameCodecStats {
  *
  * @internal
  */
+// One each, module wide. Constructing them per frame showed up in a decode
+// benchmark, and they hold no per-call state.
+const textDecoder = new TextDecoder();
+const textEncoder = new TextEncoder();
+
 export class FrameCodec {
   readonly id: string;
   readonly dictionary: Uint8Array;
@@ -109,15 +114,17 @@ export class FrameCodec {
     if (marker === FrameCodecRaw) {
       out = body;
     } else if (marker === FrameCodecCompressed) {
-      // Bounded during inflate, not after: letting it grow first means a
-      // small crafted frame can force the allocation before anything checks
-      // it. One byte over the limit is enough to detect the overflow, because
-      // fflate fills a provided buffer and reports the real length when the
-      // data fits - so a result at capacity means there was more to come.
-      const out2 = inflateSync(body, {
-        dictionary: this.dict,
-        out: new Uint8Array(maxDecompressedFrameSize + 1),
-      });
+      // Let fflate size the output. Pre-allocating the ceiling instead was
+      // measured at 341us and 16MiB of garbage per frame, for payloads of a few
+      // hundred bytes - the buffer was allocated whatever the frame turned out
+      // to weigh.
+      //
+      // What that bought was a bound applied before the allocation rather than
+      // after, and DEFLATE already bounds it: output cannot exceed roughly 1032
+      // times input, so reaching the limit below takes a frame of about 16KB.
+      // A server able to send that can send anything anyway, and the check
+      // still refuses the result.
+      const out2 = inflateSync(body, { dictionary: this.dict });
       if (out2.length > maxDecompressedFrameSize) {
         throw new Error('centrifuge: decompressed frame too large');
       }
@@ -132,7 +139,7 @@ export class FrameCodec {
     this.stats.bytesReceived += bytes.length;
     this.stats.bytesDecompressed += out.length;
 
-    return isJson ? new TextDecoder().decode(out) : out;
+    return isJson ? textDecoder.decode(out) : out;
   }
 }
 
@@ -146,7 +153,7 @@ function toBytes(data: any): Uint8Array {
   // A string can only appear here if the server sent a text frame after
   // activating compression, which it never does.
   if (typeof data === 'string') {
-    return new TextEncoder().encode(data);
+    return textEncoder.encode(data);
   }
   return new Uint8Array(data);
 }
@@ -224,7 +231,7 @@ function base64ToBytes(s: string): Uint8Array {
 export function frameByteLength(data: any): number {
   if (typeof data === 'string') {
     // A UTF-8 JSON frame: count encoded bytes, not UTF-16 code units.
-    return new TextEncoder().encode(data).length;
+    return textEncoder.encode(data).length;
   }
   if (data instanceof ArrayBuffer) {
     return data.byteLength;

--- a/src/frame_codec.ts
+++ b/src/frame_codec.ts
@@ -43,12 +43,7 @@ const maxDecompressedFrameSize = 16 * 1024 * 1024;
  */
 const maxDictionarySize = 1024 * 1024;
 
-/**
- * Dictionary.flags bit 0: content is raw DEFLATE and must be inflated with no
- * preset dictionary before use.
- * @internal
- */
-export const dictionaryFlagDeflate = 1 << 0;
+
 
 /**
  * What a connection measured about dictionary compression.
@@ -167,11 +162,9 @@ export function frameCodecFromDictionary(dictionary: any, cache?: DictionaryCach
     raw = base64ToBytes(dictionary.data_b64 || dictionary.dataB64);
   }
   const id = dictionary.id || '';
-  const flags = Number(dictionary.flags || 0);
-  if (raw !== null && (flags & dictionaryFlagDeflate) !== 0) {
-    // The first dictionary of a connection travels deflated: its delivery frame
-    // could not be compressed, because nothing was installed yet to compress it
-    // against.
+  if (raw !== null) {
+    // Content is always deflated: the frame carrying it cannot be compressed,
+    // because nothing is installed yet to compress it against.
     try {
       raw = inflateSync(raw);
     } catch (e) {

--- a/src/transport_websocket.ts
+++ b/src/transport_websocket.ts
@@ -36,9 +36,10 @@ export class WebsocketTransport {
     } else {
       this._transport = new this.options.websocket(this.endpoint);
     }
-    if (protocol === 'protobuf') {
-      this._transport.binaryType = 'arraybuffer';
-    }
+    // Always take binary messages as ArrayBuffer, not Blob. Compressed frames
+    // arrive as binary even on a JSON connection, and reading a Blob is async -
+    // which would reorder messages.
+    this._transport.binaryType = 'arraybuffer';
 
     this._transport.onopen = () => {
       callbacks.onOpen();

--- a/src/types.ts
+++ b/src/types.ts
@@ -825,10 +825,10 @@ export interface DeltaStats {
 }
 
 /**
- * CompressionStats describes what a connection measured about dictionary
- * compression on the frames it received.
+ * DictionaryCompressionStats describes what a connection measured on the frames
+ * it decoded against a dictionary.
  */
-export interface CompressionStats {
+export interface DictionaryCompressionStats {
   /** Whether the server confirmed the feature at connect. */
   accepted: boolean;
   /** Whether frames are currently being decompressed. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,6 +144,12 @@ export interface Options {
   name: string;
   /** Application version string sent with the connect command for server-side observability. */
   version: string;
+  /** Application context this connection belongs to, e.g. "trading-dashboard" or
+   * "mobile-feed". A server may use it to serve a compression dictionary built for
+   * connections of that kind. It describes the client, not the user: use a small
+   * fixed set of names, the same way as name. The server decides what to do with it
+   * and may ignore or override it, so it must never be relied on to gate anything. */
+  profile: string;
   /** Minimum delay between reconnect attempts in milliseconds. Default: 500. */
   minReconnectDelay: number;
   /** Maximum delay between reconnect attempts in milliseconds. Default: 20000. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -817,3 +817,38 @@ export interface DeltaStats {
   /** Compression ratio: 1 - (bytesReceived / bytesDecoded). 0 when bytesDecoded is 0. */
   compressionRatio: number;
 }
+
+/**
+ * CompressionStats describes what a connection measured about dictionary
+ * compression on the frames it received.
+ */
+export interface CompressionStats {
+  /** Whether the server confirmed the feature at connect. */
+  accepted: boolean;
+  /** Whether frames are currently being decompressed. */
+  active: boolean;
+  /** Identifier of the dictionary in use. */
+  dictionaryId: string;
+  /** How many compressed frames were received. */
+  frames: number;
+  /** Compressed size of those frames. */
+  bytesReceived: number;
+  /** What they expanded to. */
+  bytesDecompressed: number;
+  /** What the dictionary itself cost to receive. */
+  dictionaryBytes: number;
+  /**
+   * Net saving: what these frames would have cost uncompressed, less what they
+   * actually cost, less the dictionary transfer. Can be negative on a connection
+   * that received too little traffic to earn the dictionary back.
+   */
+  bytesSaved: number;
+  /** Uncompressed over compressed, ignoring the dictionary transfer. */
+  ratio: number;
+  /**
+   * Total bytes delivered by the transport since connect, counted before any
+   * decompression. Tracked whether or not compression is active, so the two
+   * modes can be compared directly.
+   */
+  transportBytesReceived: number;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2073,6 +2073,11 @@ fdir@^6.2.0:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
+fflate@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.8.3.tgz#bc27d8eb30343d4d512abb03480202ce65d825fc"
+  integrity sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==
+
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz"


### PR DESCRIPTION
Adds client support for connection-level dictionary compression.

A server that has one sends a shared DEFLATE dictionary in the connect reply and compresses every later frame against it. This is what a browser client needs to decode those frames, advertise a dictionary it already holds, and report what the feature actually saved.

Requires centrifugal/protocol#39, already merged; `client_proto` is regenerated from it here.

## What a user has to do

Nothing, to decode. Support is advertised automatically, and a server with no dictionary to offer behaves exactly as before.

One optional option:

```js
const centrifuge = new Centrifuge(url, {
  // Names the kind of client this is, so a server can serve a dictionary
  // built for connections of that shape.
  profile: 'trading-dashboard',
});
```

`profile` describes the client, not the user — a small fixed set of names, like `name`. The server may ignore or override it, so it must never gate anything.

## Reporting

```js
const s = centrifuge.dictionaryCompressionStats();
s.accepted          // server enabled it for this connection
s.active            // frames are being decompressed right now
s.dictionaryId      // which dictionary is in use
s.frames            // compressed frames received
s.bytesReceived     // what they cost on the wire
s.bytesDecompressed // what they expanded to
s.dictionaryBytes   // what the dictionary itself cost to receive
s.bytesSaved        // net, after subtracting the dictionary transfer
s.ratio             // uncompressed over compressed, ignoring the transfer
```

`accepted` and `active` differ by one frame: the connect reply carrying the dictionary is itself uncompressed, so decoding starts with the frame after it. `bytesSaved` subtracts the dictionary transfer deliberately and **can be negative** on a connection that received too little traffic to earn it back — that is the honest number for deciding whether the feature pays. `ratio` ignores the transfer, so the two answer different questions.

Two caveats are in the doc comment as well, because the numbers flatter the feature otherwise: they compare against sending frames uncompressed rather than against `permessage-deflate`, and they are measured on WebSocket payloads so they exclude framing.

## Bundle size

**18.6 KB → 22.1 KB gzipped** for the browser build, measured with the same esbuild invocation on `master` and on this branch.

That is `fflate`'s inflate plus the cache and codec. It buys roughly 7.5x on structured JSON payloads where a server serves a trained dictionary, so the bundle cost is repaid by the first few hundred messages — but it is a real cost for an application that never connects to a server offering one, and worth weighing on that basis.

## How it works

- **The dictionary arrives in the connect reply**, the last uncompressed frame. There is no window in which a compressed frame can arrive before the dictionary that decodes it, and no negotiation to race.
- **Frames are self-describing.** Each carries a one-byte marker saying whether it was compressed, so a server can decline any individual frame.
- **The dictionary is cached in `localStorage`** and re-advertised on reconnect, so a returning client — including after a page reload — pays an id rather than a transfer. Entries expire after seven days.
- **Cached bytes are verified against their id before use.** An id is the server's hash of the content, and DEFLATE back references resolve into the dictionary, so bytes substituted in storage would not merely corrupt a frame — they would make a genuine server frame decode into content of the substituter's choosing. Hashing on load is what prevents that; a checksum stored alongside would be rewritten with the bytes.
- **A dictionary that cannot be used is dropped.** If the server names an id this client does not hold, or a frame fails to decode, the entry is forgotten so the next connect does not advertise it again and wedge the client in a loop.

## Notes for review

- `frame_codec.ts` and `dictionary_cache.ts` are the new files; `centrifuge.ts` gains the install path and the stats accessor.
- Decompression is bounded after inflate, not before. Pre-allocating the ceiling was measured at 341us and 16MiB of garbage per frame regardless of frame size; DEFLATE already caps expansion at roughly 1032x input, so reaching the limit needs a ~16KB frame, and the check still refuses the result.
- The dictionary id derivation is reimplemented here rather than shared — it is stated on `Dictionary.id` in the protocol definition, and each implementation carries its own copy.
