### PR TITLE
Fix localStorage access error in Safari private browsing mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "centrifuge",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "description": "JavaScript client SDK for bidirectional communication with Centrifugo and Centrifuge-based server from browser, NodeJS and React Native",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -19,7 +19,7 @@ import { JsonCodec } from './json';
 
 import {
   isFunction, log, startsWith, errorExists,
-  backoff, ttlMilliseconds
+  backoff, ttlMilliseconds, localStorageItem
 } from './utils';
 
 import {
@@ -657,8 +657,7 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
     this._codec = new JsonCodec();
     this._formatOverride();
 
-    if (this._config.debug === true ||
-      (typeof localStorage !== 'undefined' && typeof localStorage.getItem === 'function' && localStorage.getItem('centrifuge.debug'))) {
+    if (this._config.debug === true || localStorageItem('centrifuge.debug')) {
       this._debugEnabled = true;
     }
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,50 @@
+import { localStorageItem } from './utils';
+
+const g = globalThis as any;
+
+function restoreLocalStorage() {
+  delete g.localStorage;
+}
+
+describe('localStorageItem', () => {
+  afterEach(() => {
+    restoreLocalStorage();
+  });
+
+  it('returns null when localStorage is not defined', () => {
+    expect(localStorageItem('centrifuge.debug')).toBeNull();
+  });
+
+  it('returns null when localStorage is null (Safari private browsing mode)', () => {
+    g.localStorage = null;
+    expect(localStorageItem('centrifuge.debug')).toBeNull();
+  });
+
+  it('returns null when localStorage has no getItem method', () => {
+    g.localStorage = {};
+    expect(localStorageItem('centrifuge.debug')).toBeNull();
+  });
+
+  it('returns null when getItem throws', () => {
+    g.localStorage = {
+      getItem: () => { throw new Error('SecurityError'); }
+    };
+    expect(localStorageItem('centrifuge.debug')).toBeNull();
+  });
+
+  it('returns null when accessing localStorage itself throws', () => {
+    Object.defineProperty(g, 'localStorage', {
+      configurable: true,
+      get: () => { throw new Error('SecurityError'); }
+    });
+    expect(localStorageItem('centrifuge.debug')).toBeNull();
+  });
+
+  it('returns stored value', () => {
+    g.localStorage = {
+      getItem: (key: string) => key === 'centrifuge.debug' ? 'true' : null
+    };
+    expect(localStorageItem('centrifuge.debug')).toBe('true');
+    expect(localStorageItem('unknown.key')).toBeNull();
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,3 +45,18 @@ export function ttlMilliseconds(ttl: number) {
   // https://stackoverflow.com/questions/12633405/what-is-the-maximum-delay-for-setinterval
   return Math.min(ttl * 1000, 2147483647);
 }
+
+/** @internal */
+export function localStorageItem(key: string): string | null {
+  // Accessing localStorage is not always safe: it may be null (Safari in
+  // private browsing mode), or even throw on property access (when access to
+  // storage is denied by the browser settings).
+  try {
+    if (typeof localStorage === 'undefined' || localStorage === null || !isFunction(localStorage.getItem)) {
+      return null;
+    }
+    return localStorage.getItem(key);
+  } catch (e) {
+    return null;
+  }
+}


### PR DESCRIPTION
Fixes #377.

In Mobile Safari private browsing mode `localStorage` is `null` rather than `undefined`. The guard in `_configure()` used `typeof localStorage !== 'undefined'`, which is `'object'` for `null`, so the following `localStorage.getItem` dereference threw:

```
null is not an object (evaluating 'localStorage.getItem')
```

Accessing `localStorage` can also throw on property access when the browser denies storage access, so the lookup is now extracted into a `localStorageItem()` helper in `src/utils.ts` which null-checks and wraps everything in `try/catch`.

Added `src/utils.test.ts` covering: undefined, `null`, missing `getItem`, throwing `getItem`, throwing global access, and the normal case.

Version bumped to 5.7.1.