### PR TITLE
Fail fast in tests when Centrifugo is not available

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   roots: ['<rootDir>/src'],
+  globalSetup: '<rootDir>/jest.globalSetup.js',
   testMatch: [
     '**/__tests__/**/*.+(ts|tsx|js)',
     '**/?(*.)+(spec|test).+(ts|tsx|js)'

--- a/jest.globalSetup.js
+++ b/jest.globalSetup.js
@@ -1,0 +1,47 @@
+// Most tests in this repo require a running Centrifugo instance (see
+// docker-compose.yml). Without it every test would hang until its own timeout,
+// making the whole run slow and the failure reason non-obvious. So probe the
+// server once before the suite starts and abort immediately with a clear hint.
+
+const http = require('http');
+
+const PROBE_URL = process.env.CENTRIFUGO_PROBE_URL || 'http://localhost:8000/';
+const TOTAL_TIMEOUT_MS = Number(process.env.CENTRIFUGO_WAIT_MS || 5000);
+const ATTEMPT_TIMEOUT_MS = 1000;
+const RETRY_DELAY_MS = 250;
+
+function probe() {
+  return new Promise((resolve) => {
+    // Any HTTP response means the server is up and accepting connections -
+    // the exact status does not matter (/health may be disabled in config).
+    const req = http.get(PROBE_URL, { timeout: ATTEMPT_TIMEOUT_MS }, (res) => {
+      res.resume();
+      resolve(null);
+    });
+    req.on('timeout', () => {
+      req.destroy();
+      resolve('timeout');
+    });
+    req.on('error', (err) => resolve(err.code || err.message || String(err)));
+  });
+}
+
+module.exports = async () => {
+  if (process.env.SKIP_CENTRIFUGO_CHECK) return;
+
+  const deadline = Date.now() + TOTAL_TIMEOUT_MS;
+  let lastError;
+  for (;;) {
+    lastError = await probe();
+    if (lastError === null) return;
+    if (Date.now() + RETRY_DELAY_MS >= deadline) break;
+    await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+  }
+
+  throw new Error(
+    `Centrifugo is not available at ${PROBE_URL} (${lastError}) after ${TOTAL_TIMEOUT_MS}ms.\n` +
+    'Tests in this repo need a running server. Start it with:\n\n' +
+    '    docker compose up -d --wait\n\n' +
+    'Set SKIP_CENTRIFUGO_CHECK=1 to bypass this check, or CENTRIFUGO_PROBE_URL to point to another instance.'
+  );
+};


### PR DESCRIPTION
Most tests in this repo need a running Centrifugo (see `docker-compose.yml`). When it's not up, every test hangs on its own timeout — the run takes forever and the actual reason is not obvious from the output.

Add a Jest `globalSetup` that probes the server before the suite starts:

- Probes `http://localhost:8000/`, retrying every 250ms with a 5s total budget (also tolerates a server that is still booting).
- If nothing answers, the whole run aborts immediately with a message pointing at `docker compose up -d --wait`.
- Any HTTP response counts as "up" — `/health` is not enabled in `centrifugo_test.json`, so the status code is deliberately ignored.

Escape hatches: `SKIP_CENTRIFUGO_CHECK=1` bypasses the check, `CENTRIFUGO_PROBE_URL` points at another instance, `CENTRIFUGO_WAIT_MS` changes the budget.

Checked locally:

- Server stopped → run aborts in ~5.5s with `Centrifugo is not available at http://localhost:8000/ (ECONNREFUSED) after 5000ms`.
- Server running → tests pass as before, probe adds a few ms.