### PR TITLE
Fix out-of-bounds transport index in _initializeTransport

### DIFF
--- a/src/centrifuge.test.ts
+++ b/src/centrifuge.test.ts
@@ -1093,3 +1093,24 @@ test.each(transportCases)("%s: unsubscribed with unauthorized", async (transport
   expect(c.state).toBe(State.Disconnected);
   expect(ctx.code).toBe(disconnectedCodes.disconnectCalled);
 });
+
+test('initializeTransport wraps current transport index instead of going out of bounds', () => {
+  // Neither transport is supported in this environment (no sockjs/webtransport globals
+  // or config provided), so both must be skipped during transport selection.
+  const c = new Centrifuge([
+    {
+      transport: 'sockjs' as TransportName,
+      endpoint: 'http://localhost:8000/connection/sockjs',
+    },
+    {
+      transport: 'webtransport' as TransportName,
+      endpoint: 'http://localhost:8000/connection/webtransport',
+    },
+  ]);
+
+  // Simulate a client which already cycled through transports on a previous
+  // connect attempt and is now resuming from the last index, not index 0.
+  (c as any)._currentTransportIndex = 1;
+
+  expect(() => { (c as any)._initializeTransport() }).toThrowError('no supported transport found');
+});

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -909,6 +909,9 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
           if (!this._transport.supported()) {
             this._debug('websocket transport not available');
             this._currentTransportIndex++;
+            if (this._currentTransportIndex >= this._transports.length) {
+              this._currentTransportIndex = 0;
+            }
             count++;
             continue;
           }
@@ -922,6 +925,9 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
           if (!this._transport.supported()) {
             this._debug('webtransport transport not available');
             this._currentTransportIndex++;
+            if (this._currentTransportIndex >= this._transports.length) {
+              this._currentTransportIndex = 0;
+            }
             count++;
             continue;
           }
@@ -937,6 +943,9 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
           if (!this._transport.supported()) {
             this._debug('http_stream transport not available');
             this._currentTransportIndex++;
+            if (this._currentTransportIndex >= this._transports.length) {
+              this._currentTransportIndex = 0;
+            }
             count++;
             continue;
           }
@@ -950,6 +959,9 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
           if (!this._transport.supported()) {
             this._debug('sse transport not available');
             this._currentTransportIndex++;
+            if (this._currentTransportIndex >= this._transports.length) {
+              this._currentTransportIndex = 0;
+            }
             count++;
             continue;
           }
@@ -962,6 +974,9 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
           if (!this._transport.supported()) {
             this._debug('sockjs transport not available');
             this._currentTransportIndex++;
+            if (this._currentTransportIndex >= this._transports.length) {
+              this._currentTransportIndex = 0;
+            }
             count++;
             continue;
           }


### PR DESCRIPTION
## Summary
- `_initializeTransport` skips unsupported transports by incrementing `_currentTransportIndex`, but resumes from whatever index it was left at on a previous call (e.g. after a transport closed before opening, which increments the index for the next reconnect attempt).
- If that resumed index is non-zero and the remaining transports through the end of the array are all unsupported, the increment walks past `_transports.length`, and the next loop iteration reads `undefined.transport`, throwing an uncaught `TypeError` instead of the intended `no supported transport found` error.
- Adds a bounds check (wrap back to 0) after each increment, matching the wrap-around logic already used at the top of the function and in the transport-close handler.

## Test plan
- [x] Added a unit test (`initializeTransport wraps current transport index instead of going out of bounds`) that starts `_currentTransportIndex` at a non-zero value with only unsupported transports configured, and asserts the clean `no supported transport found` error is thrown.
- [x] Verified the test fails with `Cannot read properties of undefined (reading 'transport')` against the unpatched code, and passes after the fix.
- [x] `npx eslint src/centrifuge.ts src/centrifuge.test.ts` clean.