### PR TITLE
Fix delta stats byte counts for non-ASCII JSON payloads

### DIFF
--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -1,0 +1,41 @@
+import { JsonCodec } from './json';
+
+describe('JsonCodec.applyDeltaIfNeeded', () => {
+  const codec = new JsonCodec();
+
+  it('reports the UTF-8 wire byte length for a full payload, not the JS string length', () => {
+    // Contains multi-byte UTF-8 characters (accents, Greek, emoji), so the
+    // UTF-16 string length differs from the actual UTF-8 byte length.
+    const data = JSON.stringify({ text: 'café 😀 δelta ünïcode' });
+    const trueByteLength = new TextEncoder().encode(data).length;
+    expect(trueByteLength).not.toBe(data.length);
+
+    const result = codec.applyDeltaIfNeeded({ delta: false, data }, null);
+
+    expect(result.wireBytes).toBe(trueByteLength);
+    expect(result.wireBytes).not.toBe(data.length);
+    expect(result.fullBytes).toBe(trueByteLength);
+    expect(result.newData).toEqual({ text: 'café 😀 δelta ünïcode' });
+  });
+
+  it('reports the UTF-8 wire byte length for a delta payload, not the JS string length', () => {
+    // A hand-built fossil delta (no copy commands, pure insert) that decodes
+    // to '{"text":"café 😀 δelta ünïcode"}'. As a raw byte array it is valid
+    // UTF-8, so the server can carry it over the wire as a JSON string —
+    // but that string's UTF-16 length is shorter than the delta's real byte size.
+    const deltaBytes = new Uint8Array([
+      98, 10, 98, 58, 123, 34, 116, 101, 120, 116, 34, 58, 34, 99, 97, 102,
+      195, 169, 32, 240, 159, 152, 128, 32, 206, 180, 101, 108, 116, 97, 32,
+      195, 188, 110, 195, 175, 99, 111, 100, 101, 34, 125, 51, 122, 103, 52,
+      84, 79, 59,
+    ]);
+    const data = new TextDecoder().decode(deltaBytes);
+    expect(deltaBytes.length).not.toBe(data.length);
+
+    const result = codec.applyDeltaIfNeeded({ delta: true, data }, new Uint8Array());
+
+    expect(result.wireBytes).toBe(deltaBytes.length);
+    expect(result.wireBytes).not.toBe(data.length);
+    expect(result.newData).toEqual({ text: 'café 😀 δelta ünïcode' });
+  });
+});

--- a/src/json.ts
+++ b/src/json.ts
@@ -15,7 +15,7 @@ export class JsonCodec {
   }
 
   applyDeltaIfNeeded(pub: any, prevValue: any) {
-    let newData: any, newPrevValue: any;
+    let newData: any, newPrevValue: any, wireBytes: number;
     let isDelta: boolean;
     if (pub.delta) {
       isDelta = true;
@@ -24,12 +24,16 @@ export class JsonCodec {
       const valueArray = applyDelta(prevValue, deltaBytes);
       newData = JSON.parse(new TextDecoder().decode(valueArray))
       newPrevValue = valueArray;
+      wireBytes = deltaBytes.length;
     } else {
       isDelta = false;
       // Full data as JSON string.
       newData = JSON.parse(pub.data);
       newPrevValue = new TextEncoder().encode(pub.data);
+      wireBytes = newPrevValue.length;
     }
-    return { newData, newPrevValue, isDelta, wireBytes: pub.data.length, fullBytes: newPrevValue.length }
+    // wireBytes is the UTF-8 byte length of pub.data, not its JS string length
+    // (.length counts UTF-16 code units, which undercounts any non-ASCII content).
+    return { newData, newPrevValue, isDelta, wireBytes, fullBytes: newPrevValue.length }
   }
 }

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -952,13 +952,16 @@ export class BaseSubscription extends (EventEmitter as new () => TypedEventEmitt
       // JSON transport with server-side delta escaping.
       // Store raw bytes for delta, decode for user.
       const rawBytes = pub.data;
+      const encoded = new TextEncoder().encode(rawBytes);
       if (!pub.removed) {
-        this._prevValueMap.set(pub.key, new TextEncoder().encode(rawBytes));
+        this._prevValueMap.set(pub.key, encoded);
       } else {
         this._prevValueMap.delete(pub.key);
       }
-      // Count as full payload in delta stats.
-      const byteLen = rawBytes.length;
+      // Count as full payload in delta stats. Use the UTF-8 byte length, not
+      // rawBytes.length (JS string length counts UTF-16 code units, which
+      // undercounts any non-ASCII content).
+      const byteLen = encoded.length;
       this._deltaNumPubs++;
       this._deltaNumFull++;
       this._deltaBytesReceived += byteLen;


### PR DESCRIPTION
## What changed

`JsonCodec.applyDeltaIfNeeded()` (src/json.ts) and `Subscription._seedDeltaTracking()` (src/subscription.ts) computed the wire byte count from the JS string `.length` of `pub.data`. That counts UTF-16 code units, not the actual UTF-8 bytes sent on the wire. For any non-ASCII payload (accented characters, non-Latin scripts, emoji, etc.) this undercounts the real byte size.

These numbers feed the public `Subscription.deltaStats()` API (`bytesReceived`, `bytesDecoded`, `compressionRatio`), which `types.ts` documents as "Total bytes received on the wire". The protobuf codec is unaffected, since its `pub.data` is already a `Uint8Array` and `.length` is a true byte count there.

Both call sites already compute (or can trivially reuse) a `TextEncoder`-encoded byte array of the same string, so the fix reuses that instead of re-deriving an incorrect count from `.length`.

## Why

Delta compression stats are meant to help users evaluate the effectiveness of `delta: 'fossil'` on their channels. For channels with non-ASCII payloads, the previous `bytesReceived`/`compressionRatio` values were quietly wrong (compression looked better than it actually was, in proportion to how many multi-byte characters the payload contained).

## How this was verified

- Added `src/json.test.ts`, a pure unit test of `JsonCodec.applyDeltaIfNeeded()` covering both the full-payload and delta-payload code paths. Each constructs a payload containing multi-byte UTF-8 characters (café, Greek δ, emoji) and asserts `wireBytes` equals the true UTF-8 byte length rather than the JS string length. The delta-path test uses a hand-built minimal fossil delta (verified independently to decode correctly via the existing `applyDelta`).
- Confirmed both new tests fail against the pre-fix code (they observe the shorter UTF-16 length) and pass after the fix.
- Kept the test in the tree: it's a small, pure, fast unit test of a previously-untested codec method, and it guards a real accounting bug that the existing ASCII-only integration tests in `delta.test.ts`/`compaction.test.ts` can't catch.
- Ran the full test suite (`npx jest`, against a local `docker compose up` Centrifugo instance): 170 passed, 3 skipped, no regressions.
- Ran `npm run build`: succeeds (pre-existing circular-dependency warning only, unrelated to this change).
- Ran `eslint` on the changed files: clean.

No public API or behavior change beyond the corrected stat values.