### PR TITLE
Fix crash on final WebTransport read chunk with no value

### DIFF
--- a/src/transport_webtransport.test.ts
+++ b/src/transport_webtransport.test.ts
@@ -1,0 +1,43 @@
+import { WebtransportTransport } from './transport_webtransport';
+
+function fakeReadableStream(chunks: (Uint8Array | undefined)[]) {
+  let i = 0;
+  return {
+    getReader() {
+      return {
+        read: async () => {
+          if (i < chunks.length) {
+            const value = chunks[i++];
+            return { done: false, value };
+          }
+          return { done: true, value: undefined };
+        }
+      };
+    }
+  };
+}
+
+describe('WebtransportTransport._startReading', () => {
+  it('does not crash on the final done chunk with no value', async () => {
+    const transport = new WebtransportTransport('https://example.com/connection/webtransport', {});
+    (transport as any)._protocol = 'json';
+    const encoder = new TextEncoder();
+    (transport as any)._stream = {
+      readable: fakeReadableStream([encoder.encode('{"id":1}\n')])
+    };
+
+    const events: string[] = [];
+    const messages: any[] = [];
+    const eventTarget = new EventTarget();
+    eventTarget.addEventListener('message', (e: any) => { events.push('message'); messages.push(e.data); });
+    eventTarget.addEventListener('close', () => { events.push('close'); });
+
+    await (transport as any)._startReading(eventTarget);
+
+    // Before the fix, `value.length` on the final {done: true, value: undefined}
+    // chunk threw, which was swallowed by the outer catch and turned into a
+    // spurious 'close' event even though the stream ended cleanly.
+    expect(messages).toEqual(['{"id":1}']);
+    expect(events).toEqual(['message']);
+  });
+});

--- a/src/transport_webtransport.ts
+++ b/src/transport_webtransport.ts
@@ -101,7 +101,7 @@ export class WebtransportTransport {
     try {
       while (true) {
         const { done, value } = await reader.read();
-        if (value.length > 0) {
+        if (value && value.length > 0) {
           if (this._protocol === 'json') {
             jsonStreamBuf += this._utf8decoder.decode(value);
             while (jsonStreamPos < jsonStreamBuf.length) {


### PR DESCRIPTION
## Summary

`WebtransportTransport._startReading` (`src/transport_webtransport.ts`) read from the WebTransport bidirectional stream's reader and checked `value.length > 0` *before* checking `done`. Per the ReadableStream reader contract, when `done: true` on the final `read()`, `value` is typically `undefined`. Accessing `.length` on it threw a `TypeError`, which was silently caught by the surrounding `try/catch` and turned into a spurious `close` event dispatch — masking a normal, clean end of stream as an error-driven close.

`transport_http_stream.ts` already handles the equivalent `reader.read()` pattern correctly (checks `done` first), so this brings `transport_webtransport.ts` in line with that.

Fix: `if (value && value.length > 0)`.

## Test plan

Added `src/transport_webtransport.test.ts`, which mocks a `ReadableStream` reader that yields one JSON chunk followed by `{ done: true, value: undefined }` (the standard terminal read), and calls `_startReading` directly.

- Before the fix: the test failed — an extra spurious `close` event was dispatched (`["message", "close"]` instead of `["message"]"`), confirming the crash-and-swallow path was hit.
- After the fix: the test passes — only the expected `message` event fires, and the stream ends cleanly with no fabricated `close`.

Verified with:
- `SKIP_CENTRIFUGO_CHECK=1 npx jest` — full suite, 169 passed, 3 skipped
- `npx eslint src/transport_webtransport.ts src/transport_webtransport.test.ts` — clean