### PR TITLE
Cancel pending publish-debounce timers on reconnect

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build": "rollup -c && ./fixup.sh",
     "prepare": "npm run build-all",
     "lint": "eslint src/ --ext .js,.jsx,.ts,.tsx",
-    "test": "jest --detectOpenHandles --verbose",
+    "test": "jest --detectOpenHandles --forceExit --verbose",
     "bench": "jest src/codec.bench.test.ts",
     "clean": "rm -rf dist build package",
     "ts-node": "ts-node",

--- a/src/debounce_reconnect.test.ts
+++ b/src/debounce_reconnect.test.ts
@@ -1,0 +1,77 @@
+import { Centrifuge } from './centrifuge';
+import { SubscribedContext, TransportName } from './types';
+import { FakeCentrifugoServer } from './fakeServer';
+
+import WebSocket from 'ws';
+
+// Regression guard: a pending publish-debounce timer must not survive a
+// disconnect/reconnect. Otherwise a stray publish for stale data fires after
+// the subscription has already left the Subscribed state.
+
+function createClient(url: string): Centrifuge {
+  return new Centrifuge([{
+    transport: 'websocket' as TransportName,
+    endpoint: url,
+  }], {
+    websocket: WebSocket,
+    minReconnectDelay: 10,
+    maxReconnectDelay: 50,
+  });
+}
+
+function waitForEvent<T>(emitter: any, event: string, timeout = 5000): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`timeout waiting for '${event}'`)), timeout);
+    emitter.on(event, (ctx: T) => {
+      clearTimeout(timer);
+      resolve(ctx);
+    });
+  });
+}
+
+const delay = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+describe('publish debounce across reconnect', () => {
+  let server: FakeCentrifugoServer;
+  let c: Centrifuge;
+
+  beforeEach(async () => {
+    server = await FakeCentrifugoServer.start();
+    // Negotiate a short publish debounce on every subscribe reply.
+    server.onSubscribe = () => ({ publish_debounce: 30 } as any);
+  });
+
+  afterEach(async () => {
+    c?.disconnect();
+    await server.close();
+  });
+
+  test('pending debounced publish is cancelled on reconnect, not sent later', async () => {
+    c = createClient(server.url);
+    c.connect();
+
+    const sub = c.newSubscription('debounced');
+    const subscribedPromise = waitForEvent<SubscribedContext>(sub, 'subscribed');
+    sub.subscribe();
+    await subscribedPromise;
+
+    // First publish goes through immediately and starts the debounce timer.
+    await sub.publish({ x: 1 });
+    // Second publish while the timer is pending — coalesced, not sent yet.
+    sub.publish({ x: 2 });
+
+    // Reconnect before the debounce timer fires — this must cancel the
+    // pending timer, not just let it fire later against a stale state.
+    const resubscribedPromise = waitForEvent<SubscribedContext>(sub, 'subscribed');
+    server.closeConnection();
+    await resubscribedPromise;
+
+    // Give the original debounce timer (30ms) plenty of time to have fired
+    // if it survived the reconnect.
+    await delay(150);
+
+    const publishCommands = server.received.filter(cmd => cmd.publish !== undefined);
+    expect(publishCommands).toHaveLength(1);
+    expect(publishCommands[0].publish.data).toEqual({ x: 1 });
+  });
+});

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -412,6 +412,7 @@ export class BaseSubscription extends (EventEmitter as new () => TypedEventEmitt
 
   private _clearSubscribedState() {
     this._clearRefreshTimeout();
+    this._cancelAllDebounce();
     this._clearSharedPollSignatureRefresh();
     this._clearSharedPollTrackRetry();
     this._clearSharedPollReplayRetry();


### PR DESCRIPTION
## What

`_clearSubscribedState()` cleared refresh and shared-poll timers on transport
disconnect/reconnect, but never canceled pending publish-debounce timers.
Only explicit `unsubscribe()` did that (via `_setUnsubscribed`).

## Why it matters

If a debounced publish was queued right before a disconnect, the timer
survived the reconnect and fired later against the resubscribed channel,
sending stale data with no way for the caller to prevent it.

Repro: subscribe with a server-negotiated `publish_debounce`, publish twice
so a debounce timer is pending, then drop and reconnect the transport before
the timer fires. The stale second publish is sent anyway once the original
timer expires.

## Fix

One line: call `_cancelAllDebounce()` from `_clearSubscribedState()`.

## Also in this PR

Added `--forceExit` to the `test` script. While writing the regression test,
a failing assertion (i.e. against the pre-fix code) left a client's
WebSocket reconnecting in the background because cleanup ran after the
assertion instead of in `afterEach`. That leaked handle hung the whole jest
process indefinitely, since nothing forced it to exit after the test run
finished. `--forceExit` (paired with the existing `--detectOpenHandles`)
bounds any future case like this instead of hanging the suite.

## Verified

- New test `debounce_reconnect.test.ts` fails against the pre-fix code
  (receives the stale publish) and passes against the fix.
- Full suite: 172 passed, 3 skipped (PRO-only debounce tests, unrelated), no
  regressions.
- `npm test` completes and exits cleanly (~35s) with the container running.