### PR TITLE
Reset server-side subscription recovery position on state invalidation

### DIFF
--- a/src/centrifuge.test.ts
+++ b/src/centrifuge.test.ts
@@ -90,6 +90,33 @@ test('state invalidated disconnect (3014) clears token and map state', () => {
   expect((sharedPollSub as any)._prevValueMap.size).toBe(0);
 });
 
+test('state invalidated disconnect (3014) resets server-side subscription recovery position', () => {
+  // Regression: server-side subscriptions cache their own recovery position
+  // separately from client-side subscriptions (_subs). 3014 must reset it too,
+  // or the next connect keeps requesting recovery from the pre-invalidation
+  // offset/epoch, defeating the point of state invalidation.
+  const c = new Centrifuge([{
+    transport: 'websocket' as TransportName,
+    endpoint: 'ws://localhost:8000/connection/websocket',
+  }], {
+    websocket: WebSocket,
+  });
+
+  (c as any)._serverSubs['news'] = {
+    offset: 5,
+    epoch: 'server-epoch',
+    recoverable: true,
+  };
+
+  (c as any)._handleDisconnect({ code: 3014, reason: 'state invalidated' });
+
+  expect((c as any)._serverSubs['news'].offset).toBe(0);
+  expect((c as any)._serverSubs['news'].epoch).toBe('_');
+  // recoverable left untouched — recovery is still requested, just from the
+  // sentinel position the server can never match.
+  expect((c as any)._serverSubs['news'].recoverable).toBe(true);
+});
+
 test('state invalidated unsubscribe (2502) clears sub token and map state', () => {
   const c = new Centrifuge([{
     transport: 'websocket' as TransportName,

--- a/src/centrifuge.ts
+++ b/src/centrifuge.ts
@@ -1468,6 +1468,16 @@ export class Centrifuge extends (EventEmitter as new () => TypedEventEmitter<Cli
           this._subs[channel]._invalidateState();
         }
       }
+      // Server-side subscriptions carry their own cached recovery position,
+      // separate from the client-side subscriptions above — reset it to the
+      // same unrecoverable sentinel so the next connect can't recover from
+      // now-invalidated state.
+      for (const channel in this._serverSubs) {
+        if (this._serverSubs.hasOwnProperty(channel)) {
+          this._serverSubs[channel].offset = 0;
+          this._serverSubs[channel].epoch = '_';
+        }
+      }
     }
     if (this._isDisconnected()) {
       return;


### PR DESCRIPTION
## Summary
- Disconnect code 3014 (state invalidated) reset client-side subscriptions' cached offset/epoch to the unrecoverable sentinel, but server-side subscriptions (`_serverSubs`) were left untouched.
- The connect request unconditionally sends each `_serverSubs` entry's cached offset/epoch as recovery params on every reconnect, so an app using only server-side subscriptions kept requesting recovery from the stale pre-invalidation position after a 3014, defeating the point of state invalidation.
- Mirrors the fix already applied in centrifuge-swift (centrifugal/centrifuge-swift#135).

## Test plan
- [x] Added `state invalidated disconnect (3014) resets server-side subscription recovery position` in `src/centrifuge.test.ts`, asserting offset/epoch reset to `0`/`"_"` while `recoverable` is left untouched.
- [x] `SKIP_CENTRIFUGO_CHECK=1 npx jest src/centrifuge.test.ts -t "state invalidated"` passes.
- [x] `npx eslint src/centrifuge.ts src/centrifuge.test.ts` clean.