### PR TITLE
Fix UTF-8 corruption when a character spans two stream chunks

### DIFF
--- a/src/transport_http_stream.test.ts
+++ b/src/transport_http_stream.test.ts
@@ -1,0 +1,48 @@
+import { HttpStreamTransport } from './transport_http_stream';
+
+function fakeBody(chunks: Uint8Array[]) {
+  let i = 0;
+  return {
+    getReader() {
+      return {
+        read: async () => {
+          if (i < chunks.length) {
+            return { done: false, value: chunks[i++] };
+          }
+          return { done: true, value: undefined };
+        }
+      };
+    }
+  };
+}
+
+// Minimal stand-in for ReadableStream: just runs the underlying source's start().
+class FakeReadableStream {
+  constructor(source: any) {
+    source.start({ close() { /* no-op */ } });
+  }
+}
+
+describe('HttpStreamTransport JSON stream parsing', () => {
+  it('decodes a multi-byte character split across two chunks', async () => {
+    const payload = JSON.stringify({ data: 'привет 🎉' });
+    const full = new TextEncoder().encode(payload + '\n');
+    // Split in the middle of the first Cyrillic character (2-byte sequence).
+    const splitAt = payload.indexOf('привет') + 1;
+
+    const transport = new HttpStreamTransport('https://example.com/connection/http_stream', {
+      fetch: async () => ({ ok: true, body: fakeBody([full.slice(0, splitAt), full.slice(splitAt)]) }),
+      readableStream: FakeReadableStream
+    });
+
+    const messages: any[] = [];
+    const eventTarget = (transport as any)._fetchEventTarget(transport, 'https://example.com', {});
+    eventTarget.addEventListener('message', (e: any) => { messages.push(e.data); });
+    const closed = new Promise<void>(resolve => eventTarget.addEventListener('close', () => resolve()));
+    await closed;
+
+    // Without {stream: true} the decoder would emit U+FFFD for the bytes of the
+    // character straddling the chunk boundary.
+    expect(messages).toEqual([payload]);
+  });
+});

--- a/src/transport_http_stream.ts
+++ b/src/transport_http_stream.ts
@@ -55,7 +55,10 @@ export class HttpStreamTransport {
                 }
                 try {
                   if (self._protocol === 'json') {
-                    jsonStreamBuf += self._utf8decoder.decode(value);
+                    // stream: true keeps decoder state across reads so a multi-byte
+                    // UTF-8 character split across two chunks is not corrupted into
+                    // replacement characters.
+                    jsonStreamBuf += self._utf8decoder.decode(value, { stream: true });
                     while (jsonStreamPos < jsonStreamBuf.length) {
                       if (jsonStreamBuf[jsonStreamPos] === '\n') {
                         const line = jsonStreamBuf.substring(0, jsonStreamPos);

--- a/src/transport_webtransport.test.ts
+++ b/src/transport_webtransport.test.ts
@@ -41,3 +41,27 @@ describe('WebtransportTransport._startReading', () => {
     expect(events).toEqual(['message']);
   });
 });
+
+describe('WebtransportTransport._startReading UTF-8 handling', () => {
+  it('decodes a multi-byte character split across two chunks', async () => {
+    const transport = new WebtransportTransport('https://example.com/connection/webtransport', {});
+    (transport as any)._protocol = 'json';
+    const payload = JSON.stringify({ data: 'привет 🎉' });
+    const full = new TextEncoder().encode(payload + '\n');
+    // Split in the middle of the first Cyrillic character (2-byte sequence).
+    const splitAt = payload.indexOf('привет') + 1;
+    (transport as any)._stream = {
+      readable: fakeReadableStream([full.slice(0, splitAt), full.slice(splitAt)])
+    };
+
+    const messages: any[] = [];
+    const eventTarget = new EventTarget();
+    eventTarget.addEventListener('message', (e: any) => { messages.push(e.data); });
+
+    await (transport as any)._startReading(eventTarget);
+
+    // Without {stream: true} the decoder would emit U+FFFD for the bytes of the
+    // character straddling the chunk boundary.
+    expect(messages).toEqual([payload]);
+  });
+});

--- a/src/transport_webtransport.ts
+++ b/src/transport_webtransport.ts
@@ -103,7 +103,10 @@ export class WebtransportTransport {
         const { done, value } = await reader.read();
         if (value && value.length > 0) {
           if (this._protocol === 'json') {
-            jsonStreamBuf += this._utf8decoder.decode(value);
+            // stream: true keeps decoder state across reads so a multi-byte
+            // UTF-8 character split across two chunks is not corrupted into
+            // replacement characters.
+            jsonStreamBuf += this._utf8decoder.decode(value, { stream: true });
             while (jsonStreamPos < jsonStreamBuf.length) {
               if (jsonStreamBuf[jsonStreamPos] === '\n') {
                 const line = jsonStreamBuf.substring(0, jsonStreamPos);


### PR DESCRIPTION
## What

`HttpStreamTransport` and `WebtransportTransport` parse the JSON protocol by
appending decoded text to a line buffer:

```ts
jsonStreamBuf += this._utf8decoder.decode(value);
```

`TextDecoder.decode()` without `{ stream: true }` treats every call as a
complete input. Any multi-byte UTF-8 sequence that happens to straddle a chunk
boundary gets its leading bytes replaced with `U+FFFD` and its trailing bytes
decoded as a separate broken character.

Network/stream chunk boundaries are arbitrary, so this can hit any publication
containing non-ASCII data (Cyrillic, CJK, emoji, accented Latin, …) on these two
transports — the payload is silently mangled, or `JSON.parse` throws on the
resulting line.

## Why this fix

Passing `{ stream: true }` makes the decoder retain the incomplete tail until
the continuation bytes arrive in the next read. This is safe here: `_utf8decoder`
is a per-transport-instance field and `_initializeTransport` constructs a fresh
transport for every connection attempt, so no decoder state carries across
connections.

Not affected, and left alone:

- the protobuf branches of both transports, which accumulate raw `Uint8Array`
  bytes and let the codec find frame boundaries;
- `SseTransport`, where `EventSource` does its own decoding.

## Verification

Added two regression tests, one per transport, both server-free unit tests that
drive the existing read loops with a fake reader:

- `src/transport_webtransport.test.ts` — feeds `{"data":"привет 🎉"}\n` to
  `_startReading` as two chunks split in the middle of the first Cyrillic
  character's 2-byte sequence, and asserts the dispatched message equals the
  original payload.
- `src/transport_http_stream.test.ts` (new file) — same payload and split point
  through `_fetchEventTarget`, with a stub `fetch` and a minimal
  `readableStream` stand-in, waiting on the `close` event before asserting.

Both are kept in the tree: they guard a real class of regression (chunked UTF-8
decoding), aren't covered elsewhere, and only touch the read loops' observable
message output rather than internals.

Against the unpatched transports both fail with:

```
- "{\"data\":\"привет 🎉\"}"
+ "{\"data\":\"��ривет 🎉\"}"
```

and pass with the fix. Also ran `eslint src/` (clean) and `rollup -c` (builds,
only the pre-existing circular-dependency warnings).